### PR TITLE
ignore incompatible windows and arm64 combination

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
+      - goos: windows
+        goarch: arm64
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
   - format: zip


### PR DESCRIPTION
goreleaser fails on the combination of windows and arm64, so add an ignore entry for that.