### PR TITLE
Adds support for adding stack tags on Cloudformation templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.4] - (unreleased)
+
+### Changed
+- Added tags support to Cloudformation template resource
+
+
 ## [0.3.3] - 2023-03-10
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This Makefile is an easy way to run common operations.
 
-VERSION=0.3.3
+VERSION=0.3.4
 
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=github.com

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ resource "kion_aws_cloudformation_template" "t1" {
     }
 }
 EOF
+  tags = {
+    Owner      = "jdoe"
+    Department = "DevOps"
+  }
 }
 
 # Output the ID of the resource created.

--- a/docs/data-sources/aws_cloudformation_template.md
+++ b/docs/data-sources/aws_cloudformation_template.md
@@ -51,6 +51,7 @@ Read-Only:
 - `region` (String)
 - `regions` (List of String)
 - `sns_arns` (String)
+- `tags` (Map)
 - `template_parameters` (String)
 - `termination_protection` (Boolean)
 

--- a/kion/data_source_aws_cloudformation_template.go
+++ b/kion/data_source_aws_cloudformation_template.go
@@ -99,6 +99,11 @@ func dataSourceAwsCloudformationTemplate() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"tags": {
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
 						"template_parameters": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -118,7 +123,7 @@ func dataSourceAwsCloudformationTemplateRead(ctx context.Context, d *schema.Reso
 	var diags diag.Diagnostics
 	c := m.(*hc.Client)
 
-	resp := new(hc.CFTListResponseWithOwners)
+	resp := new(hc.CFTListResponseWithOwnersAndTags)
 	err := c.GET("/v3/cft", resp)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
@@ -143,6 +148,7 @@ func dataSourceAwsCloudformationTemplateRead(ctx context.Context, d *schema.Reso
 		data["region"] = item.Cft.Region
 		data["regions"] = hc.FilterStringArray(item.Cft.Regions)
 		data["sns_arns"] = item.Cft.SnsArns
+		data["tags"] = hc.InflateTags(item.Tags)
 		data["template_parameters"] = item.Cft.TemplateParameters
 		data["termination_protection"] = item.Cft.TerminationProtection
 

--- a/kion/internal/ctclient/helper.go
+++ b/kion/internal/ctclient/helper.go
@@ -199,7 +199,7 @@ func InflateTags(arr []Tag) map[string]string {
 		return final
 	}
 
-	return make(map[string]string, 0)
+	return nil
 }
 
 // FieldsChanged -

--- a/kion/internal/ctclient/helper.go
+++ b/kion/internal/ctclient/helper.go
@@ -146,6 +146,20 @@ func FlattenGenericIDPointer(d *schema.ResourceData, key string) *[]int {
 	return &uids
 }
 
+func FlattenTags(d *schema.ResourceData, key string) *[]Tag {
+	tagMap := d.Get(key).(map[string]interface{})
+
+	tags := make([]Tag, 0)
+	for k, v := range tagMap {
+		tags = append(tags, Tag{
+			Key:   k,
+			Value: v.(string),
+		})
+	}
+
+	return &tags
+}
+
 // InflateObjectWithID -
 func InflateObjectWithID(arr []ObjectWithID) []interface{} {
 	if arr != nil {
@@ -172,6 +186,20 @@ func InflateSingleObjectWithID(single *ObjectWithID) interface{} {
 	}
 
 	return nil
+}
+
+func InflateTags(arr []Tag) map[string]string {
+	if arr != nil {
+		final := make(map[string]string, 0)
+
+		for _, item := range arr {
+			final[item.Key] = item.Value
+		}
+
+		return final
+	}
+
+	return make(map[string]string, 0)
 }
 
 // FieldsChanged -

--- a/kion/internal/ctclient/models_aws_cloudformation_template.go
+++ b/kion/internal/ctclient/models_aws_cloudformation_template.go
@@ -1,7 +1,7 @@
 package ctclient
 
-// CFTListResponseWithOwners for: GET /api/v3/cft
-type CFTListResponseWithOwners struct {
+// CFTListResponseWithOwnersAndTags for: GET /api/v3/cft
+type CFTListResponseWithOwnersAndTags struct {
 	Data []struct {
 		Cft struct {
 			Description           string   `json:"description"`
@@ -16,12 +16,13 @@ type CFTListResponseWithOwners struct {
 		} `json:"cft"`
 		OwnerUserGroups []ObjectWithID `json:"owner_user_groups"`
 		OwnerUsers      []ObjectWithID `json:"owner_users"`
+		Tags            []Tag          `json:"tags"`
 	} `json:"data"`
 	Status int `json:"status"`
 }
 
-// CFTResponseWithOwners for: GET /api/v3/cft/{id}
-type CFTResponseWithOwners struct {
+// CFTResponseWithOwnersAndTags for: GET /api/v3/cft/{id}
+type CFTResponseWithOwnersAndTags struct {
 	Data struct {
 		Cft struct {
 			Description           string   `json:"description"`
@@ -36,6 +37,7 @@ type CFTResponseWithOwners struct {
 		} `json:"cft"`
 		OwnerUserGroups []ObjectWithID `json:"owner_user_groups"`
 		OwnerUsers      []ObjectWithID `json:"owner_users"`
+		Tags            []Tag          `json:"tags"`
 	} `json:"data"`
 	Status int `json:"status"`
 }
@@ -50,6 +52,7 @@ type CFTCreate struct {
 	Region                string   `json:"region"`
 	Regions               []string `json:"regions"`
 	SnsArns               string   `json:"sns_arns"`
+	Tags                  *[]Tag   `json:"tags"`
 	TemplateParameters    string   `json:"template_parameters"`
 	TerminationProtection bool     `json:"termination_protection"`
 }
@@ -62,6 +65,7 @@ type CFTUpdate struct {
 	Region                string   `json:"region"`
 	Regions               []string `json:"regions"`
 	SnsArns               string   `json:"sns_arns"`
+	Tags                  *[]Tag   `json:"tags"`
 	TemplateParameters    string   `json:"template_parameters"`
 	TerminationProtection bool     `json:"termination_protection"`
 }

--- a/kion/internal/ctclient/models_shared.go
+++ b/kion/internal/ctclient/models_shared.go
@@ -43,3 +43,8 @@ type ChangeOwners struct {
 	OwnerUserGroupIds *[]int `json:"owner_user_group_ids"`
 	OwnerUserIds      *[]int `json:"owner_user_ids"`
 }
+
+type Tag struct {
+	Key   string `json:"tag_key"`
+	Value string `json:"tag_value"`
+}


### PR DESCRIPTION
Adds support for adding tags to CloudFormation templates.  This requires Kion version 3.7.1 or greater.

For example:

```
resource "kion_aws_cloudformation_template" "example" {
  name        = "tf-example"
  description = "Sample CFT"
  regions     = ["us-east-1"]
  owner_users { id = 1 }
  policy = "---\nResources:\n  MyEC2Instance:\n    Type: 'AWS::EC2::Instance'\n    Properties:\n      ImageId: ami-0c94855ba95c71c99\n      InstanceType: t2.micro\n      KeyName: mykeypair\nOutputs:\n  InstanceId:\n    Value: !Ref MyEC2Instance"

  tags = {
    Name           = "tf-example"
    Department     = "DevOps"
    Owner          = "jdoe"
  }
}
```