### PR TITLE
Update funding source resource and datasource

### DIFF
--- a/kion/data_source_funding_source.go
+++ b/kion/data_source_funding_source.go
@@ -1,0 +1,135 @@
+package kion
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	hc "github.com/kionsoftware/terraform-provider-kion/kion/internal/ctclient"
+)
+
+func dataSourceFundingSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceFundingSourceRead,
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Description: "The field name whose values you wish to filter by.",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"values": {
+							Description: "The values of the field name you specified.",
+							Type:        schema.TypeList,
+							Required:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"regex": {
+							Description: "Dictates if the values provided should be treated as regular expressions.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
+					},
+				},
+			},
+			"list": {
+				Description: "This is where Kion makes the discovered data available as a list of resources.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"amount": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"start_datecode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"end_datecode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ou_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceFundingSourceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	c := m.(*hc.Client)
+
+	resp := new(hc.FundingSourceListResponse)
+	err := c.GET("/v3/funding-source", resp)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to read Funding Source",
+			Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), "all"),
+		})
+		return diags
+	}
+
+	f := hc.NewFilterable(d)
+
+	arr := make([]map[string]interface{}, 0)
+	for _, item := range resp.Data {
+		data := make(map[string]interface{})
+		data["amount"] = item.Amount
+		data["description"] = item.Description
+		data["name"] = item.Name
+		data["ou_id"] = item.OUID
+		data["start_datecode"] = item.StartDatecode
+		data["end_datecode"] = item.EndDatecode
+
+		match, err := f.Match(data)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to filter Funding Source",
+				Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), "filter"),
+			})
+			return diags
+		} else if !match {
+			continue
+		}
+
+		arr = append(arr, data)
+	}
+
+	if err := d.Set("list", arr); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to read Funding Source",
+			Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), "all"),
+		})
+		return diags
+	}
+
+	// Always run.
+	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
+
+	return diags
+}

--- a/kion/internal/ctclient/helper.go
+++ b/kion/internal/ctclient/helper.go
@@ -2,6 +2,7 @@ package ctclient
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -172,6 +173,25 @@ func InflateSingleObjectWithID(single *ObjectWithID) interface{} {
 	}
 
 	return nil
+}
+
+// InflateArrayOfIDs - Transforms an array of IDs into a map with an "id" key
+func InflateArrayOfIDs(arr []int) []interface{} {
+	if arr != nil {
+		final := make([]interface{}, 0)
+
+		for _, item := range arr {
+			it := make(map[string]interface{})
+
+			it["id"] = item
+
+			final = append(final, it)
+		}
+
+		return final
+	}
+
+	return make([]interface{}, 0)
 }
 
 // FieldsChanged -

--- a/kion/internal/ctclient/models_funding_source.go
+++ b/kion/internal/ctclient/models_funding_source.go
@@ -1,0 +1,55 @@
+package ctclient
+
+// FundingSourceListResponse for: GET /api/v3/funding-source
+type FundingSourceListResponse struct {
+	Data []struct {
+		ID            int    `json:"id"`
+		Amount        int    `json:"amount"`
+		Description   string `json:"description"`
+		EndDatecode   string `json:"end_datecode"`
+		Name          string `json:"name"`
+		OUID          int    `json:"ou_id"`
+		StartDatecode string `json:"start_datecode"`
+	} `json:"data"`
+	Status int `json:"status"`
+}
+
+// FundingSourceResponse for: GET /api/v3/funding-source/{id}
+type FundingSourceResponse struct {
+	Data struct {
+		ID                 int    `json:"id"`
+		Amount             int    `json:"amount"`
+		Description        string `json:"description"`
+		EndDatecode        string `json:"end_datecode"`
+		Name               string `json:"name"`
+		OUID               int    `json:"ou_id"`
+		StartDatecode      string `json:"start_datecode"`
+		PermissionSchemeID int    `json:"permission_scheme_id"`
+	} `json:"data"`
+	Status int `json:"status"`
+}
+
+// FundingSourceCreate for: POST /api/v3/funding-source
+type FundingSourceCreate struct {
+	ID                 int    `json:"id"`
+	Amount             int    `json:"amount"`
+	Description        string `json:"description"`
+	EndDatecode        string `json:"end_datecode"`
+	Name               string `json:"name"`
+	StartDatecode      string `json:"start_datecode"`
+	PermissionSchemeID int    `json:"permission_scheme_id"`
+	OUID               int    `json:"ou_id"`
+	OwnerUserGroupIds  *[]int `json:"owner_user_group_ids"`
+	OwnerUserIds       *[]int `json:"owner_user_ids"`
+}
+
+// FundingSourceUpdate for: PATCH /api/v3/funding-source/{id}
+type FundingSourceUpdate struct {
+	ID            int    `json:"id"`
+	Amount        int    `json:"amount"`
+	Description   string `json:"description"`
+	EndDatecode   string `json:"end_datecode"`
+	Name          string `json:"name"`
+	OUID          int    `json:"ou_id"`
+	StartDatecode string `json:"start_datecode"`
+}

--- a/kion/internal/ctclient/models_funding_source.go
+++ b/kion/internal/ctclient/models_funding_source.go
@@ -53,3 +53,18 @@ type FundingSourceUpdate struct {
 	OUID          int    `json:"ou_id"`
 	StartDatecode string `json:"start_datecode"`
 }
+
+// FundingSourcePermissionMapping
+type FundingSourcePermissionMapping struct {
+	AppRoleID    int    `json:"app_role_id"`
+	UserGroupIds *[]int `json:"user_groups_ids"`
+	UserIds      *[]int `json:"user_ids"`
+}
+
+type FSUserMappingListResponse struct {
+	Data []struct {
+		AppRoleId    int    `json:"app_role_id"`
+		UserGroupIds *[]int `json:"user_groups_ids"`
+		UserIds      *[]int `json:"user_ids"`
+	}
+}

--- a/kion/internal/ctclient/models_shared.go
+++ b/kion/internal/ctclient/models_shared.go
@@ -43,10 +43,3 @@ type ChangeOwners struct {
 	OwnerUserGroupIds *[]int `json:"owner_user_group_ids"`
 	OwnerUserIds      *[]int `json:"owner_user_ids"`
 }
-
-// FundingSourcePermissionMapping
-type FundingSourcePermissionMapping struct {
-	AppRoleID    int    `json:"app_role_id"`
-	UserGroupIds *[]int `json:"user_group_ids"`
-	UserIds      *[]int `json:"user_ids"`
-}

--- a/kion/internal/ctclient/models_shared.go
+++ b/kion/internal/ctclient/models_shared.go
@@ -43,3 +43,10 @@ type ChangeOwners struct {
 	OwnerUserGroupIds *[]int `json:"owner_user_group_ids"`
 	OwnerUserIds      *[]int `json:"owner_user_ids"`
 }
+
+// FundingSourcePermissionMapping
+type FundingSourcePermissionMapping struct {
+	AppRoleID    int    `json:"app_role_id"`
+	UserGroupIds *[]int `json:"user_group_ids"`
+	UserIds      *[]int `json:"user_ids"`
+}

--- a/kion/provider.go
+++ b/kion/provider.go
@@ -59,6 +59,7 @@ func Provider() *schema.Provider {
 			"kion_cloud_rule":                  dataSourceCloudRule(),
 			"kion_compliance_check":            dataSourceComplianceCheck(),
 			"kion_compliance_standard":         dataSourceComplianceStandard(),
+			"kion_funding_source":              dataSourceFundingSource(),
 			"kion_ou":                          dataSourceOU(),
 			"kion_user_group":                  dataSourceUserGroup(),
 			"kion_saml_group_association":      dataSourceSamlGroupAssociation(),

--- a/kion/provider.go
+++ b/kion/provider.go
@@ -40,6 +40,7 @@ func Provider() *schema.Provider {
 			"kion_cloud_rule":                  resourceCloudRule(),
 			"kion_compliance_check":            resourceComplianceCheck(),
 			"kion_compliance_standard":         resourceComplianceStandard(),
+			"kion_funding_source":              resourceFundingSource(),
 			"kion_ou_cloud_access_role":        resourceOUCloudAccessRole(),
 			"kion_project_cloud_access_role":   resourceProjectCloudAccessRole(),
 			"kion_ou":                          resourceOU(),

--- a/kion/resource_funding_source.go
+++ b/kion/resource_funding_source.go
@@ -273,7 +273,7 @@ func resourceFundingSourceDelete(ctx context.Context, d *schema.ResourceData, m 
 	c := m.(*hc.Client)
 	ID := d.Id()
 
-	err := c.DELETE(fmt.Sprintf("/v1/funding-source/%s", ID), nil)
+	err := c.DELETE(fmt.Sprintf("/v3/funding-source/%s", ID), nil)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/kion/resource_funding_source.go
+++ b/kion/resource_funding_source.go
@@ -1,0 +1,269 @@
+package kion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	hc "github.com/kionsoftware/terraform-provider-kion/kion/internal/ctclient"
+)
+
+func resourceFundingSource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFundingSourceCreate,
+		ReadContext:   resourceFundingSourceRead,
+		UpdateContext: resourceFundingSourceUpdate,
+		DeleteContext: resourceFundingSourceDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+				resourceFundingSourceRead(ctx, d, m)
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+		Schema: map[string]*schema.Schema{
+			// Notice there is no 'id' field specified because it will be created.
+			"last_updated": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"amount": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"start_datecode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"end_datecode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ou_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"owner_user_ids": {
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+				Type:         schema.TypeSet,
+				Optional:     true,
+				Description:  "Must provide at least the owner_user_groups field or the owner_users field.",
+				AtLeastOneOf: []string{"owner_user_group_ids", "owner_user_ids"},
+			},
+			"owner_user_group_ids": {
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+				Type:         schema.TypeSet,
+				Optional:     true,
+				Description:  "Must provide at least the owner_user_groups field or the owner_users field.",
+				AtLeastOneOf: []string{"owner_user_group_ids", "owner_user_ids"},
+			},
+			"permission_scheme_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceFundingSourceCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	c := m.(*hc.Client)
+
+	post := hc.FundingSourceCreate{
+		Amount:             d.Get("amount").(int),
+		Description:        d.Get("description").(string),
+		Name:               d.Get("name").(string),
+		StartDatecode:      d.Get("start_datecode").(string),
+		EndDatecode:        d.Get("end_datecode").(string),
+		PermissionSchemeID: d.Get("permission_scheme_id").(int),
+		OUID:               d.Get("ou_id").(int),
+		OwnerUserIds:       hc.FlattenGenericIDPointer(d, "owner_user_ids"),
+		OwnerUserGroupIds:  hc.FlattenGenericIDPointer(d, "owner_user_group_ids"),
+	}
+
+	resp, err := c.POST("/v3/funding-source", post)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to create Funding Source",
+			Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), post),
+		})
+		return diags
+	} else if resp.RecordID == 0 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to create Funding Source",
+			Detail:   fmt.Sprintf("Error: %v\nItem: %v", errors.New("received item ID of 0"), post),
+		})
+		return diags
+	}
+
+	d.SetId(strconv.Itoa(resp.RecordID))
+
+	resourceFundingSourceRead(ctx, d, m)
+
+	return diags
+}
+
+func resourceFundingSourceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	c := m.(*hc.Client)
+	ID := d.Id()
+
+	resp := new(hc.FundingSourceResponse)
+	err := c.GET(fmt.Sprintf("/v3/funding-source/%s", ID), resp)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to read Funding Source",
+			Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), ID),
+		})
+		return diags
+	}
+	item := resp.Data
+
+	data := make(map[string]interface{})
+	data["amount"] = item.Amount
+	data["description"] = item.Description
+	data["name"] = item.Name
+	data["ou_id"] = item.OUID
+	data["start_datecode"] = item.StartDatecode
+	data["end_datecode"] = item.EndDatecode
+
+	for k, v := range data {
+		if err := d.Set(k, v); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to read and set Funding Source",
+				Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), ID),
+			})
+			return diags
+		}
+	}
+
+	return diags
+}
+
+func resourceFundingSourceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	c := m.(*hc.Client)
+	ID := d.Id()
+
+	hasChanged := 0
+
+	// Determine if the attributes that are updatable are changed.
+	// Leave out fields that are not allowed to be changed like
+	// `aws_iam_path` in AWS IAM policies and add `ForceNew: true` to the
+	// schema instead.
+	if d.HasChanges(
+		"amount",
+		"description",
+		"end_datecode",
+		"name",
+		"ou_id",
+		"start_datecode") {
+		hasChanged++
+		req := hc.FundingSourceUpdate{
+			Amount:        d.Get("amount").(int),
+			Description:   d.Get("description").(string),
+			Name:          d.Get("name").(string),
+			EndDatecode:   d.Get("end_datecode").(string),
+			StartDatecode: d.Get("start_datecode").(string),
+		}
+
+		err := c.PATCH(fmt.Sprintf("/v3/funding-source/%s", ID), req)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to update Funding Source",
+				Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), ID),
+			})
+			return diags
+		}
+	}
+
+	// Determine if the owners have changed.
+	if d.HasChanges("owner_user_ids",
+		"owner_user_group_ids") {
+		hasChanged++
+		arrAddOwnerUserGroupIds, arrRemoveOwnerUserGroupIds, _, _ := hc.AssociationChanged(d, "owner_user_group_ids")
+		arrAddOwnerUserIds, arrRemoveOwnerUserIds, _, _ := hc.AssociationChanged(d, "owner_user_ids")
+
+		patch := []hc.FundingSourcePermissionMapping{
+			{
+				AppRoleID:    1,
+				UserGroupIds: &arrAddOwnerUserGroupIds,
+				UserIds:      &arrAddOwnerUserIds,
+			},
+		}
+
+		if len(arrAddOwnerUserGroupIds) > 0 ||
+			len(arrAddOwnerUserIds) > 0 ||
+			len(arrRemoveOwnerUserGroupIds) > 0 ||
+			len(arrRemoveOwnerUserIds) > 0 {
+			err := c.PATCH(fmt.Sprintf("/v3/funding-source/%s/permission-mapping", ID), patch)
+			if err != nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Unable to change permission mapping on Funding Source",
+					Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), ID),
+				})
+				return diags
+			}
+		}
+	}
+
+	if hasChanged > 0 {
+		d.Set("last_updated", time.Now().Format(time.RFC850))
+	}
+
+	return resourceFundingSourceRead(ctx, d, m)
+}
+
+func resourceFundingSourceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	c := m.(*hc.Client)
+	ID := d.Id()
+
+	err := c.DELETE(fmt.Sprintf("/v1/funding-source/%s", ID), nil)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to delete Funding Source",
+			Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), ID),
+		})
+		return diags
+	}
+
+	// d.SetId("") is automatically called assuming delete returns no errors, but
+	// it is added here for explicitness.
+	d.SetId("")
+
+	return diags
+}

--- a/kion/resource_funding_source.go
+++ b/kion/resource_funding_source.go
@@ -218,8 +218,8 @@ func resourceFundingSourceUpdate(ctx context.Context, d *schema.ResourceData, m 
 		patch := []hc.FundingSourcePermissionMapping{
 			{
 				AppRoleID:    1,
-				UserGroupIds: &arrAddOwnerUserGroupIds,
-				UserIds:      &arrAddOwnerUserIds,
+				UserGroupIds: hc.FlattenGenericIDPointer(d, "owner_user_groups"),
+				UserIds:      hc.FlattenGenericIDPointer(d, "owner_users"),
 			},
 		}
 

--- a/kion/resource_funding_source.go
+++ b/kion/resource_funding_source.go
@@ -55,7 +55,7 @@ func resourceFundingSource() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
-			"owner_user_ids": {
+			"owner_users": {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -67,9 +67,9 @@ func resourceFundingSource() *schema.Resource {
 				Type:         schema.TypeSet,
 				Optional:     true,
 				Description:  "Must provide at least the owner_user_groups field or the owner_users field.",
-				AtLeastOneOf: []string{"owner_user_group_ids", "owner_user_ids"},
+				AtLeastOneOf: []string{"owner_user_groups", "owner_users"},
 			},
-			"owner_user_group_ids": {
+			"owner_user_groups": {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -81,7 +81,7 @@ func resourceFundingSource() *schema.Resource {
 				Type:         schema.TypeSet,
 				Optional:     true,
 				Description:  "Must provide at least the owner_user_groups field or the owner_users field.",
-				AtLeastOneOf: []string{"owner_user_group_ids", "owner_user_ids"},
+				AtLeastOneOf: []string{"owner_user_groups", "owner_users"},
 			},
 			"permission_scheme_id": {
 				Type:     schema.TypeInt,
@@ -103,8 +103,8 @@ func resourceFundingSourceCreate(ctx context.Context, d *schema.ResourceData, m 
 		EndDatecode:        d.Get("end_datecode").(string),
 		PermissionSchemeID: d.Get("permission_scheme_id").(int),
 		OUID:               d.Get("ou_id").(int),
-		OwnerUserIds:       hc.FlattenGenericIDPointer(d, "owner_user_ids"),
-		OwnerUserGroupIds:  hc.FlattenGenericIDPointer(d, "owner_user_group_ids"),
+		OwnerUserIds:       hc.FlattenGenericIDPointer(d, "owner_users"),
+		OwnerUserGroupIds:  hc.FlattenGenericIDPointer(d, "owner_user_groups"),
 	}
 
 	resp, err := c.POST("/v3/funding-source", post)
@@ -209,11 +209,11 @@ func resourceFundingSourceUpdate(ctx context.Context, d *schema.ResourceData, m 
 	}
 
 	// Determine if the owners have changed.
-	if d.HasChanges("owner_user_ids",
-		"owner_user_group_ids") {
+	if d.HasChanges("owner_users",
+		"owner_user_groups") {
 		hasChanged++
-		arrAddOwnerUserGroupIds, arrRemoveOwnerUserGroupIds, _, _ := hc.AssociationChanged(d, "owner_user_group_ids")
-		arrAddOwnerUserIds, arrRemoveOwnerUserIds, _, _ := hc.AssociationChanged(d, "owner_user_ids")
+		arrAddOwnerUserGroupIds, arrRemoveOwnerUserGroupIds, _, _ := hc.AssociationChanged(d, "owner_user_groups")
+		arrAddOwnerUserIds, arrRemoveOwnerUserIds, _, _ := hc.AssociationChanged(d, "owner_users")
 
 		patch := []hc.FundingSourcePermissionMapping{
 			{


### PR DESCRIPTION
#23 should be merged first.

This updates a few things in the new funding source resource from @joraff in #23:

* Changes `owner_user_ids` to `owner_users` and changes `owner_user_group_ids` to `owner_user_groups`.  The provider tends to use the latter in more places.
* Fix a small bug when updating funding source user/group permissions.  This ensures all provided users/groups are set, not just those that have changed.
* Include user/group permissions when fetching funding sources



