### PR TITLE
Add an apipath provider parameter

### DIFF
--- a/kion/internal/ctclient/client.go
+++ b/kion/internal/ctclient/client.go
@@ -24,7 +24,7 @@ type Client struct {
 }
 
 // NewClient .
-func NewClient(ctURL string, ctAPIKey string, skipSSLValidation bool) *Client {
+func NewClient(ctURL string, ctAPIKey string, ctAPIPath string, skipSSLValidation bool) *Client {
 	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 	customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: skipSSLValidation}
 
@@ -34,12 +34,12 @@ func NewClient(ctURL string, ctAPIKey string, skipSSLValidation bool) *Client {
 		},
 	}
 
-	// Append '/api' to the URL.
+	// Append the path to the URL.
 	u, err := url.Parse(ctURL)
 	if err != nil {
 		log.Fatalln("The URL is not valid:", ctURL, err.Error())
 	}
-	u.Path = path.Join(u.Path, "api")
+	u.Path = path.Join(u.Path, ctAPIPath)
 	c.HostURL = u.String()
 
 	c.Token = ctAPIKey

--- a/kion/internal/ctclient/helper.go
+++ b/kion/internal/ctclient/helper.go
@@ -2,6 +2,7 @@ package ctclient
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/kion/provider.go
+++ b/kion/provider.go
@@ -26,6 +26,12 @@ func Provider() *schema.Provider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("KION_APIKEY", nil),
 			},
+			"apipath": {
+				Description: "The base path of the API.  Defaults to /api",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "/api",
+			},
 			"skipsslvalidation": {
 				Description: "If true, will skip SSL validation.",
 				Type:        schema.TypeBool,
@@ -74,6 +80,7 @@ func Provider() *schema.Provider {
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	ctURL := d.Get("url").(string)
 	ctAPIKey := d.Get("apikey").(string)
+	ctAPIPath := d.Get("apipath").(string)
 
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
@@ -85,7 +92,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		skipSSLValidation = t
 	}
 
-	c := ctclient.NewClient(ctURL, ctAPIKey, skipSSLValidation)
+	c := ctclient.NewClient(ctURL, ctAPIKey, ctAPIPath, skipSSLValidation)
 	err := c.GET("/v3/me/cloud-access-role", nil)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{


### PR DESCRIPTION
This allows changing the default `/api` path for instances where the Kion API is hosted at a different path.

There should be no need to change existing provider configs as the default value is the current behavior.