### PR TITLE
Check for trailing slashes in URL and apipath

### DIFF
--- a/kion/internal/ctclient/client.go
+++ b/kion/internal/ctclient/client.go
@@ -39,7 +39,7 @@ func NewClient(ctURL string, ctAPIKey string, ctAPIPath string, skipSSLValidatio
 	if err != nil {
 		log.Fatalln("The URL is not valid:", ctURL, err.Error())
 	}
-	u.Path = path.Join(u.Path, ctAPIPath)
+	u.Path = path.Join(strings.TrimRight(u.Path, "/"), strings.TrimRight(ctAPIPath, "/"))
 	c.HostURL = u.String()
 
 	c.Token = ctAPIKey


### PR DESCRIPTION
This fixes a bug that caused double slashes in URLs depending on whether the url or apipath parameter have trailing slashes.