### PR TITLE
Add ID prefix to allow importing existing accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.8] - 2024-01-03
+- Fixed an issue that prevented importing existing Kion accounts into the terraform state.  When importing existing accounts, the user should specify the account ID using an `account_id=` or `account_cache_id=` prefix to tell the terraform provider whether the provided ID is an account ID or a cached account ID.  See the README for more information.
+
 ## [0.3.7] - 2023-12-21
 - Added `kion_aws_account`, `kion_gcp_account` and `kion_azure_account` resources ([#32](https://github.com/kionsoftware/terraform-provider-kion/pull/32))
 - Added `kion_account` and `kion_cached_account` data sources

--- a/README.md
+++ b/README.md
@@ -429,6 +429,18 @@ resource "kion_aws_account" "test2" {
 }
 ```
 
+Special note:  When importing an existing Kion account into your terraform state file, you must
+use the `account_id=` or `account_cache_id=` ID prefix to indicate whether the ID is an account ID
+or a cached account ID.
+
+For example:
+
+    ```
+    terraform import kion_aws_account.test1 account_id=123
+    terraform import kion_aws_account.test2 account_cache_id=321
+    ```
+
+
 ```hcl
 # Import an existing GCP project to the account cache:
 resource "kion_gcp_account" "test3" {
@@ -450,6 +462,17 @@ resource "kion_gcp_account" "test4" {
   start_datecode = "2023-01"
 }
 ```
+
+Special note:  When importing an existing Kion account into your terraform state file, you must
+use the `account_id=` or `account_cache_id=` ID prefix to indicate whether the ID is an account ID
+or a cached account ID.
+
+For example:
+
+    ```
+    terraform import kion_gcp_account.test3 account_id=123
+    terraform import kion_gcp_account.test4 account_cache_id=321
+    ```
 
 ```hcl
 # Import an existing Azure subscription to a project:
@@ -474,6 +497,17 @@ resource "kion_azure_account" "test6" {
     billing_profile_invoice = "SH3V-xxxx-xxx-xxx"
   }
 ```
+
+Special note:  When importing an existing Kion account into your terraform state file, you must
+use the `account_id=` or `account_cache_id=` ID prefix to indicate whether the ID is an account ID
+or a cached account ID.
+
+For example:
+
+    ```
+    terraform import kion_azure_account.test5 account_id=123
+    terraform import kion_azure_account.test6 account_cache_id=321
+    ```
 
 ```hcl
 # Create a GCP IAM role.

--- a/docs/resources/aws_account.md
+++ b/docs/resources/aws_account.md
@@ -6,6 +6,11 @@ description: |-
   Creates or imports an AWS Account and adds it to a Kion project or the Kion account cache.
   If account_number is provided, an existing account will be imported into Kion, otherwise a new AWS account will be created.  If project_id is provided the account will be added to the corresponding project, otherwise the account will be added to the account cache.
   Once added, an account can be moved between projects or in and out of the account cache by changing the project_id.  When moving accounts between projects, use move_project_settings to control how financials will be treated between the old and new project.
+  When importing an existing Kion account into terraform state (different from using terraform to import an existing AWS account into Kion), you must use the account_id= or account_cache_id= ID prefix to indicate whether the ID is an account ID or a cached account ID.
+  For example:
+  terraform import kion_aws_account.test-account account_id=123
+  terraform import kion_aws_account.test-cached-account account_cache_id=321
+  
   NOTE: This resource requires Kion v3.8.4 or greater.
 ---
 
@@ -16,6 +21,13 @@ Creates or imports an AWS Account and adds it to a Kion project or the Kion acco
 If `account_number` is provided, an existing account will be imported into Kion, otherwise a new AWS account will be created.  If `project_id` is provided the account will be added to the corresponding project, otherwise the account will be added to the account cache.
 
 Once added, an account can be moved between projects or in and out of the account cache by changing the `project_id`.  When moving accounts between projects, use `move_project_settings` to control how financials will be treated between the old and new project.
+
+When importing an existing Kion account into terraform state (different from using terraform to import an existing AWS account into Kion), you must use the `account_id=` or `account_cache_id=` ID prefix to indicate whether the ID is an account ID or a cached account ID.
+
+For example:
+
+    terraform import kion_aws_account.test-account account_id=123
+    terraform import kion_aws_account.test-cached-account account_cache_id=321
 
 **NOTE:** This resource requires Kion v3.8.4 or greater.
 

--- a/docs/resources/azure_account.md
+++ b/docs/resources/azure_account.md
@@ -6,6 +6,11 @@ description: |-
   Creates or imports an Azure Subscription and adds it to a Kion project or the Kion account cache.
   If subscription_uuid is provided, an existing subscription will be imported into Kion, otherwise a new Azure subscription will be created.  If project_id is provided the account will be added to the corresponding project, otherwise the account will be added to the account cache.
   Once added, an account can be moved between projects or in and out of the account cache by changing the project_id.  When moving accounts between projects, use move_project_settings to control how financials will be treated between the old and new project.
+  When importing an existing Kion account into terraform state (different from using terraform to import an existing Azure subscription into Kion), you must use the account_id= or account_cache_id= ID prefix to indicate whether the ID is an account ID or a cached account ID.
+  For example:
+  terraform import kion_azure_account.test-account account_id=123
+  terraform import kion_azure_account.test-cached-account account_cache_id=321
+  
   NOTE: This resource requires Kion v3.8.4 or greater.
 ---
 
@@ -16,6 +21,13 @@ Creates or imports an Azure Subscription and adds it to a Kion project or the Ki
 If `subscription_uuid` is provided, an existing subscription will be imported into Kion, otherwise a new Azure subscription will be created.  If `project_id` is provided the account will be added to the corresponding project, otherwise the account will be added to the account cache.
 
 Once added, an account can be moved between projects or in and out of the account cache by changing the `project_id`.  When moving accounts between projects, use `move_project_settings` to control how financials will be treated between the old and new project.
+
+When importing an existing Kion account into terraform state (different from using terraform to import an existing Azure subscription into Kion), you must use the `account_id=` or `account_cache_id=` ID prefix to indicate whether the ID is an account ID or a cached account ID.
+
+For example:
+
+    terraform import kion_azure_account.test-account account_id=123
+    terraform import kion_azure_account.test-cached-account account_cache_id=321
 
 **NOTE:** This resource requires Kion v3.8.4 or greater.
 

--- a/docs/resources/gcp_account.md
+++ b/docs/resources/gcp_account.md
@@ -6,6 +6,11 @@ description: |-
   Creates or imports a Google Cloud Project and adds it to a Kion project or the Kion account cache.
   If create_mode is set to import, an existing project will be imported into Kion, otherwise if create_mode is set to create, a new GCP Project will be created.  If project_id is provided the account will be added to the corresponding project, otherwise the account will be added to the account cache.
   Once added, an account can be moved between projects or in and out of the account cache by changing the project_id.  When moving accounts between projects, use move_project_settings to control how financials will be treated between the old and new project.
+  When importing an existing Kion account into terraform state (different from using terraform to import an existing GCP Project into Kion), you must use the account_id= or account_cache_id= ID prefix to indicate whether the ID is an account ID or a cached account ID.
+  For example:
+  terraform import kion_gcp_account.test-account account_id=123
+  terraform import kion_gcp_account.test-cached-account account_cache_id=321
+  
   NOTE: This resource requires Kion v3.8.4 or greater.
 ---
 
@@ -16,6 +21,13 @@ Creates or imports a Google Cloud Project and adds it to a Kion project or the K
 If `create_mode` is set to import, an existing project will be imported into Kion, otherwise if `create_mode` is set to create, a new GCP Project will be created.  If `project_id` is provided the account will be added to the corresponding project, otherwise the account will be added to the account cache.
 
 Once added, an account can be moved between projects or in and out of the account cache by changing the `project_id`.  When moving accounts between projects, use `move_project_settings` to control how financials will be treated between the old and new project.
+
+When importing an existing Kion account into terraform state (different from using terraform to import an existing GCP Project into Kion), you must use the `account_id=` or `account_cache_id=` ID prefix to indicate whether the ID is an account ID or a cached account ID.
+
+For example:
+
+    terraform import kion_gcp_account.test-account account_id=123
+    terraform import kion_gcp_account.test-cached-account account_cache_id=321
 
 **NOTE:** This resource requires Kion v3.8.4 or greater.
 

--- a/kion/resource_aws_account.go
+++ b/kion/resource_aws_account.go
@@ -27,6 +27,12 @@ func resourceAwsAccount() *schema.Resource {
 			"Once added, an account can be moved between projects or in and out of the account cache by " +
 			"changing the `project_id`.  When moving accounts between projects, use `move_project_settings` " +
 			"to control how financials will be treated between the old and new project.\n\n" +
+			"When importing an existing Kion account into terraform state (different from using terraform to " +
+			"import an existing AWS account into Kion), you must use the `account_id=` or `account_cache_id=` " +
+			"ID prefix to indicate whether the ID is an account ID or a cached account ID.\n\n" +
+			"For example:\n\n" +
+			"    terraform import kion_aws_account.test-account account_id=123\n" +
+			"    terraform import kion_aws_account.test-cached-account account_cache_id=321\n\n" +
 			"**NOTE:** This resource requires Kion v3.8.4 or greater.",
 		CreateContext: resourceAwsAccountCreate,
 		ReadContext:   resourceAwsAccountRead,

--- a/kion/resource_azure_account.go
+++ b/kion/resource_azure_account.go
@@ -27,6 +27,12 @@ func resourceAzureAccount() *schema.Resource {
 			"Once added, an account can be moved between projects or in and out of the account cache by " +
 			"changing the `project_id`.  When moving accounts between projects, use `move_project_settings` " +
 			"to control how financials will be treated between the old and new project.\n\n" +
+			"When importing an existing Kion account into terraform state (different from using terraform to " +
+			"import an existing Azure subscription into Kion), you must use the `account_id=` or `account_cache_id=` " +
+			"ID prefix to indicate whether the ID is an account ID or a cached account ID.\n\n" +
+			"For example:\n\n" +
+			"    terraform import kion_azure_account.test-account account_id=123\n" +
+			"    terraform import kion_azure_account.test-cached-account account_cache_id=321\n\n" +
 			"**NOTE:** This resource requires Kion v3.8.4 or greater.",
 		CreateContext: resourceAzureAccountCreate,
 		ReadContext:   resourceAzureAccountRead,

--- a/kion/resource_gcp_account.go
+++ b/kion/resource_gcp_account.go
@@ -29,6 +29,12 @@ func resourceGcpAccount() *schema.Resource {
 			"Once added, an account can be moved between projects or in and out of the account cache by " +
 			"changing the `project_id`.  When moving accounts between projects, use `move_project_settings` " +
 			"to control how financials will be treated between the old and new project.\n\n" +
+			"When importing an existing Kion account into terraform state (different from using terraform to " +
+			"import an existing GCP Project into Kion), you must use the `account_id=` or `account_cache_id=` " +
+			"ID prefix to indicate whether the ID is an account ID or a cached account ID.\n\n" +
+			"For example:\n\n" +
+			"    terraform import kion_gcp_account.test-account account_id=123\n" +
+			"    terraform import kion_gcp_account.test-cached-account account_cache_id=321\n\n" +
 			"**NOTE:** This resource requires Kion v3.8.4 or greater.",
 		CreateContext: resourceGcpAccountCreate,
 		ReadContext:   resourceGcpAccountRead,


### PR DESCRIPTION
This fixes a bug that prevented importing existing Kion accounts into a terraform statefile.

Specifically, a command like the following would fail:

```
terraform import kion_aws_account.test1 123
```

The underlying issue is that during import, the provider doesn't know if the ID being imported is an account ID or a cached account ID.  In Kion, accounts and cached accounts have different IDs.  Unfortunately during import the provider doesn't have visibility into the rest of the resource data so we can't use project_id to determine if its a cached account id or regular account id (or at least I don't know how to get the provider to see this info during import).

To work around this we are adding support for specifying a special "ID prefix" when importing accounts.  Now you specify the ID with an `account_id=` or `account_cache_id=` prefix when importing.

For example:

```
terraform import kion_aws_account.test1 account_id=123
# or
terraform import kion_aws_account.test2 account_cache_id=321
```