### PR TITLE
Update GitHub Action with Enhancements for Automated Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,46 +1,46 @@
-# This GitHub action can publish assets for release when a tag is created.
-# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
-#
-# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your
-# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
-# secret. If you would rather own your own GPG handling, please fork this action
-# or use an alternative one for key handling.
-#
-# You will need to pass the `--batch` flag to `gpg` in your signing step
-# in `goreleaser` to indicate this is being used in a non-interactive mode.
-#
+# This GitHub action publishes assets for a release when a tag is created.
+# It's configured to trigger on tags that match the pattern "v*" (e.g., v0.1.0).
+
+# We use the 'crazy-max/ghaction-import-gpg' action for GPG key handling.
+# Ensure your private key and passphrase are set in the `GPG_PRIVATE_KEY` and `PASSPHRASE` secrets, respectively.
+
+# For GoReleaser, ensure it is configured correctly for non-interactive mode as necessary.
+# This setup is streamlined for simplicity and efficiency in automating the release process.
+
 name: release
+
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - name: Unshallow
         run: git fetch --prune --unshallow
+
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.21.5
+          go-version: '^1.21.5'
+
       - name: Import GPG key
         id: import_gpg
-        # TODO: move this to HashiCorp namespace or find alternative that is just simple gpg commands
-        # see https://github.com/hashicorp/terraform-provider-scaffolding/issues/22
-        uses: paultyng/ghaction-import-gpg@v2.1.0
-        env:
-          # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          # GitHub sets this automatically
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces several updates and improvements to our GitHub Actions release automation workflow. The goal is to enhance our release process's performance, security, and maintainability. Below are the key changes included:

- **Checkout Action Upgrade**: Moved from `actions/checkout@v2` to `actions/checkout@v4` to benefit from the latest features and performance improvements.
- **Go Environment Setup**: Updated to `actions/setup-go@v4`, adopting the latest version and enabling automatic minor and patch version updates for Go.
- **GPG Key Handling**: Transitioned to using `crazy-max/ghaction-import-gpg@v6` for importing GPG keys, offering a more robust and flexible approach to security.
- **GoReleaser Configuration**: Adjusted the GoReleaser action arguments to use `--clean`, optimizing the artifact publishing process.
- **Documentation and Comments**: Updated comments within the GitHub action configuration to better reflect the current setup and practices, removing outdated references and ensuring clarity.

These changes aim to streamline our release process, ensuring it is efficient, secure, and easy to maintain. The upgrades to the latest versions of actions and the switch to a more flexible GPG key handling solution position us well for future development and releases.