### PR TITLE
Add retry for aws accounts switching from cache to project

### DIFF
--- a/kion/resource_account.go
+++ b/kion/resource_account.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -360,23 +359,6 @@ func convertCacheAccountToProjectAccount(c *hc.Client, accountCacheId, newProjec
 	}
 
 	return resp.RecordID, nil
-}
-
-func retryConvertCacheAccountToProjectAccountForAWS(c *hc.Client, accountCacheId, projectId int, startDatecode string, retries int, delay time.Duration) (int, error) {
-	var lastErr error
-	for i := 0; i < retries; i++ {
-		id, err := convertCacheAccountToProjectAccount(c, accountCacheId, projectId, startDatecode)
-		if err == nil {
-			return id, nil
-		}
-		if strings.Contains(err.Error(), "Rule is already in progress") && i < retries-1 {
-			time.Sleep(delay)
-			continue
-		}
-		lastErr = err
-		break
-	}
-	return 0, lastErr
 }
 
 func convertProjectAccountToCacheAccount(c *hc.Client, accountId int) (int, error) {

--- a/kion/resource_account.go
+++ b/kion/resource_account.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -359,6 +360,23 @@ func convertCacheAccountToProjectAccount(c *hc.Client, accountCacheId, newProjec
 	}
 
 	return resp.RecordID, nil
+}
+
+func retryConvertCacheAccountToProjectAccountForAWS(c *hc.Client, accountCacheId, projectId int, startDatecode string, retries int, delay time.Duration) (int, error) {
+	var lastErr error
+	for i := 0; i < retries; i++ {
+		id, err := convertCacheAccountToProjectAccount(c, accountCacheId, projectId, startDatecode)
+		if err == nil {
+			return id, nil
+		}
+		if strings.Contains(err.Error(), "Rule is already in progress") && i < retries-1 {
+			time.Sleep(delay)
+			continue
+		}
+		lastErr = err
+		break
+	}
+	return 0, lastErr
 }
 
 func convertProjectAccountToCacheAccount(c *hc.Client, accountId int) (int, error) {

--- a/kion/resource_aws_account.go
+++ b/kion/resource_aws_account.go
@@ -376,8 +376,10 @@ func resourceAwsAccountCreate(ctx context.Context, d *schema.ResourceData, m int
 			// Move cached account to the requested project
 			projectId := d.Get("project_id").(int)
 			startDatecode := time.Now().Format("200601")
+			retries := 3              // Number of retries
+			delay := 30 * time.Second // Delay between retries
 
-			newId, err := convertCacheAccountToProjectAccount(c, accountCacheId, projectId, startDatecode)
+			newId, err := retryConvertCacheAccountToProjectAccountForAWS(c, accountCacheId, projectId, startDatecode, retries, delay)
 			if err != nil {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,


### PR DESCRIPTION
Add a retry mechanism due to what seems like a race condition with Cloudformation stacks getting created for Kion roles.  