### PR TITLE
Add Dev Build and Added a Mutex for AWS Account Creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ default: build
 build:
 	go build -o ${BINARY}
 
+build-dev:
+	go build -gcflags="all=-N -l" -o ${BINARY}
+
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
 	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
@@ -57,6 +60,10 @@ release:
 	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
 
 install: build
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+
+install-dev: build-dev
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 

--- a/kion/provider.go
+++ b/kion/provider.go
@@ -3,11 +3,14 @@ package kion
 
 import (
 	"context"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/kionsoftware/terraform-provider-kion/kion/internal/ctclient"
 )
+
+var awsAccountCreationMux sync.Mutex
 
 // Provider -
 func Provider() *schema.Provider {

--- a/kion/resource_aws_account.go
+++ b/kion/resource_aws_account.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -208,90 +207,6 @@ func resourceAwsAccount() *schema.Resource {
 	}
 }
 
-func createAwsAccount(ctx context.Context, c *hc.Client, postCacheData hc.AccountCacheNewAWSCreate, d *schema.ResourceData) (diag.Diagnostics, int) {
-	var diags diag.Diagnostics
-
-	// Lock to ensure one account creation process at a time as AWS Orgs cannot handle more than one account creation at a time.
-	awsAccountCreationMux.Lock()
-	defer awsAccountCreationMux.Unlock()
-
-	// Populate organizational unit details from Terraform resource data, if provided by user.
-	if err := populateOrgUnitFromResourceData(c, &postCacheData, d); err != nil {
-		return diag.FromErr(err), 0
-	}
-
-	// Send the POST request to create the AWS account.
-	respCache, err := c.POST("/v3/account-cache/create?account-type=aws", postCacheData)
-	if err != nil || respCache.RecordID == 0 {
-		if err == nil {
-			err = fmt.Errorf("received item ID of 0")
-		}
-		return diag.Errorf("Unable to create AWS Account: %v", err), 0
-	}
-
-	// Wait for the account to be fully created.
-	if err := waitForAccountCreation(c, ctx, respCache.RecordID, d); err != nil {
-		return diag.FromErr(err), 0
-	}
-
-	// Return any diagnostics and the ID of the created account cache.
-	return diags, respCache.RecordID
-}
-
-// populateOrgUnitFromResourceData parses OU details from Terraform data, updating AccountCacheNewAWSCreate for account creation.
-func populateOrgUnitFromResourceData(c *hc.Client, postCacheData *hc.AccountCacheNewAWSCreate, d *schema.ResourceData) error {
-	if v, exists := d.GetOk("aws_organizational_unit"); exists {
-		orgUnitSet := v.(*schema.Set)
-		for _, item := range orgUnitSet.List() {
-			orgUnitMap, ok := item.(map[string]interface{})
-			if !ok {
-				return fmt.Errorf("invalid format for aws_organizational_unit")
-			}
-			postCacheData.OrganizationalUnit = &hc.PayerOrganizationalUnit{
-				Name:      orgUnitMap["name"].(string),
-				OrgUnitId: orgUnitMap["org_unit_id"].(string),
-			}
-		}
-	}
-	return nil
-}
-
-// waitForAccountCreation polls the creation status until the account is created or a timeout occurs.
-func waitForAccountCreation(c *hc.Client, ctx context.Context, accountCacheId int, d *schema.ResourceData) error {
-	createStateConf := &resource.StateChangeConf{
-		// Define the refresh function, which checks the account creation status.
-		Refresh: func() (interface{}, string, error) {
-			resp := new(hc.AccountResponse)
-			err := c.GET(fmt.Sprintf("/v3/account-cache/%d", accountCacheId), resp)
-			if err != nil {
-				// Handle the case where the account is not found as a transient state, not an error.
-				if resErr, ok := err.(*hc.RequestError); ok && resErr.StatusCode == http.StatusNotFound {
-					tflog.Trace(ctx, fmt.Sprintf("Checking new AWS account status: /v3/account-cache/%d not found", accountCacheId), map[string]interface{}{"accountCacheId": accountCacheId})
-					return nil, "NotFound", nil
-				}
-				tflog.Trace(ctx, fmt.Sprintf("Checking new AWS account status: /v3/account-cache/%d error", accountCacheId), map[string]interface{}{"error": err, "accountCacheId": accountCacheId})
-				return nil, "Error", err
-			}
-
-			// Check if the account number is still not available in the response.
-			if resp.Data.AccountNumber == "" {
-				tflog.Trace(ctx, fmt.Sprintf("Checking new AWS account status: /v3/account-cache/%d missing account number", accountCacheId), map[string]interface{}{"accountCacheId": accountCacheId})
-				return resp, "MissingAccountNumber", nil
-			}
-
-			// Account creation is successful.
-			return resp, "AccountCreated", nil
-		},
-		Pending: []string{"MissingAccountNumber", "NotFound"},
-		Target:  []string{"AccountCreated"},
-		Timeout: d.Timeout(schema.TimeoutCreate),
-	}
-
-	// Wait for the account to reach the target state.
-	_, err := createStateConf.WaitForStateContext(ctx)
-	return err
-}
-
 func resourceAwsAccountCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := m.(*hc.Client)
@@ -369,20 +284,8 @@ func resourceAwsAccountCreate(ctx context.Context, d *schema.ResourceData, m int
 		d.SetId(strconv.Itoa(resp.RecordID))
 
 	} else {
-		// Prepare the data structure for AWS account creation.
-		postCacheData := hc.AccountCacheNewAWSCreate{
-			AccountEmail:              d.Get("email").(string),
-			Name:                      d.Get("name").(string),
-			CommercialAccountName:     d.Get("commercial_account_name").(string),
-			CreateGovcloud:            hc.OptionalBool(d, "create_govcloud"),
-			GovAccountName:            d.Get("gov_account_name").(string),
-			IncludeLinkedAccountSpend: hc.OptionalBool(d, "include_linked_account_spend"),
-			LinkedRole:                d.Get("linked_role").(string),
-			PayerID:                   d.Get("payer_id").(int),
-		}
-
-		// Call the createAwsAccount function to initiate the account creation process.
-		diags, accountCacheId := createAwsAccount(ctx, c, postCacheData, d)
+		// Call the createAwsAccount function
+		diags, accountCacheId := createAwsAccount(ctx, c, d)
 		if diags.HasError() {
 			return diags
 		}
@@ -435,6 +338,113 @@ func resourceAwsAccountCreate(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	return append(diags, resourceAwsAccountRead(ctx, d, m)...)
+}
+
+func createAwsAccount(ctx context.Context, c *hc.Client, d *schema.ResourceData) (diag.Diagnostics, int) {
+	var diags diag.Diagnostics
+
+	// Lock to ensure one account creation process at a time as AWS Orgs cannot handle more than one account creation at a time.
+	awsAccountCreationMux.Lock()
+	defer awsAccountCreationMux.Unlock()
+
+	postCacheData := hc.AccountCacheNewAWSCreate{
+		AccountEmail:              d.Get("email").(string),
+		Name:                      d.Get("name").(string),
+		CommercialAccountName:     d.Get("commercial_account_name").(string),
+		CreateGovcloud:            hc.OptionalBool(d, "create_govcloud"),
+		GovAccountName:            d.Get("gov_account_name").(string),
+		IncludeLinkedAccountSpend: hc.OptionalBool(d, "include_linked_account_spend"),
+		LinkedRole:                d.Get("linked_role").(string),
+		PayerID:                   d.Get("payer_id").(int),
+	}
+
+	// Populate organizational unit details from Terraform resource data, if provided by user.
+	if err := populateOrgUnitFromResourceData(c, &postCacheData, d); err != nil {
+		return diag.FromErr(err), 0
+	}
+
+	// Log the account creation POST data.
+	if err := logPostData(ctx, c, postCacheData); err != nil {
+		// If logging fails, only warn instead of failing the operation.
+		tflog.Warn(ctx, "Failed to log post data for AWS account creation", map[string]interface{}{"error": err.Error()})
+	}
+
+	// Send the POST request to create the AWS account.
+	respCache, err := c.POST("/v3/account-cache/create?account-type=aws", postCacheData)
+	if err != nil || respCache.RecordID == 0 {
+		if err == nil {
+			err = fmt.Errorf("received item ID of 0")
+		}
+		return diag.Errorf("Unable to create AWS Account: %v", err), 0
+	}
+
+	// Wait for the account to be fully created.
+	if err := waitForAccountCreation(c, ctx, respCache.RecordID, d); err != nil {
+		return diag.FromErr(err), 0
+	}
+
+	// Return any diagnostics and the ID of the created account cache.
+	return diags, respCache.RecordID
+}
+
+// logPostData logs the data being posted for account creation. It returns an error if marshalling fails.
+func logPostData(ctx context.Context, c *hc.Client, postData interface{}) error {
+	rb, err := json.Marshal(postData)
+	if err != nil {
+		return err
+	}
+	tflog.Debug(ctx, "Creating new AWS account via POST /v3/account-cache/create?account-type=aws", map[string]interface{}{"postData": string(rb)})
+	return nil
+}
+
+// populateOrgUnitFromResourceData parses OU details from Terraform data, updating AccountCacheNewAWSCreate for account creation.
+func populateOrgUnitFromResourceData(c *hc.Client, postCacheData *hc.AccountCacheNewAWSCreate, d *schema.ResourceData) error {
+	if v, exists := d.GetOk("aws_organizational_unit"); exists {
+		orgUnitSet := v.(*schema.Set)
+		for _, item := range orgUnitSet.List() {
+			orgUnitMap, ok := item.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("invalid format for aws_organizational_unit")
+			}
+			postCacheData.OrganizationalUnit = &hc.PayerOrganizationalUnit{
+				Name:      orgUnitMap["name"].(string),
+				OrgUnitId: orgUnitMap["org_unit_id"].(string),
+			}
+		}
+	}
+	return nil
+}
+
+// waitForAccountCreation polls the creation status until the account is created or a timeout occurs.
+func waitForAccountCreation(c *hc.Client, ctx context.Context, accountCacheId int, d *schema.ResourceData) error {
+	createStateConf := &resource.StateChangeConf{
+		// Define the refresh function, which checks the account creation status.
+		Refresh: func() (interface{}, string, error) {
+			resp := new(hc.AccountResponse)
+			err := c.GET(fmt.Sprintf("/v3/account-cache/%d", accountCacheId), resp)
+			if err != nil {
+				// Directly return errors, including NotFound, allowing the SDK to handle retries for NotFound appropriately.
+				tflog.Trace(ctx, fmt.Sprintf("Checking new AWS account status: /v3/account-cache/%d error", accountCacheId), map[string]interface{}{"error": err, "accountCacheId": accountCacheId})
+				return nil, "", err
+			}
+
+			// Check if the account number is still not available in the response.
+			if resp.Data.AccountNumber == "" {
+				tflog.Trace(ctx, fmt.Sprintf("Checking new AWS account status: /v3/account-cache/%d missing account number", accountCacheId), map[string]interface{}{"accountCacheId": accountCacheId})
+				return resp, "MissingAccountNumber", nil
+			}
+
+			// Account creation is successful.
+			return resp, "AccountCreated", nil
+		},
+		Pending: []string{"MissingAccountNumber"},
+		Target:  []string{"AccountCreated"},
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+
+	// Use WaitForStateContext to respect the given context's deadline or cancellation.
+	_, err := createStateConf.WaitForStateContext(ctx)
+	return err // Return the error, if any.
 }
 
 func retryConvertCacheAccountToProjectAccountForAWS(c *hc.Client, accountCacheId, projectId int, startDatecode string, retries int, delay time.Duration) (int, error) {


### PR DESCRIPTION
## PR Description:
This pull request introduces several enhancements and refactoring changes to the Makefile and the Terraform provider for Kion. The key changes include adding a development build option, introducing a sync mechanism for AWS account creation, and refactoring AWS account creation logic into a dedicated function. Below are the details of the changes:

### Makefile Changes:
I introduced a new `build-dev` target that compiles the binary with Go's `-N—l` flags for disabling optimizations and inlining, facilitating easier debugging.
- Added an `install-dev` target that utilizes the newly created `build-dev` target for development purposes.

### Terraform Provider Changes:
- Incorporated a mutex (`awsAccountCreationMux`) globally in `provider.go` to lock AWS account creation processes. This addresses the issue of concurrent account creations leading to failures due to AWS Organizations' limitations on simultaneous account creation.
- Refactored the AWS account creation logic in `resource_aws_account.go` into a new function, `createAwsAccount`, improving code readability and maintainability. This function includes mutex logic, ensuring that account creation requests are processed one at a time.