### PR TITLE
Fix: Prevent unnecessary label updates when labels are not defined in HCL

### DIFF
--- a/kion/resource_cloud_rule.go
+++ b/kion/resource_cloud_rule.go
@@ -293,14 +293,14 @@ func resourceCloudRuleCreate(ctx context.Context, d *schema.ResourceData, m inte
 
 	d.SetId(strconv.Itoa(resp.RecordID))
 
-	if d.Get("labels") != nil {
+	if labels, ok := d.GetOk("labels"); ok && labels != nil {
 		ID := d.Id()
 		err = hc.PutAppLabelIDs(client, hc.FlattenAssociateLabels(d, "labels"), "cloud-rule", ID)
 
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
-				Summary:  "Unable to update cloud rule labels",
+				Summary:  "Unable to update Cloud Rule labels",
 				Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), ID),
 			})
 			return diags

--- a/kion/resource_funding_source.go
+++ b/kion/resource_funding_source.go
@@ -132,14 +132,14 @@ func resourceFundingSourceCreate(ctx context.Context, d *schema.ResourceData, m 
 
 	d.SetId(strconv.Itoa(resp.RecordID))
 
-	if d.Get("labels") != nil {
+	if labels, ok := d.GetOk("labels"); ok && labels != nil {
 		ID := d.Id()
 		err = hc.PutAppLabelIDs(client, hc.FlattenAssociateLabels(d, "labels"), "funding-source", ID)
 
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
-				Summary:  "Unable to update funding source labels",
+				Summary:  "Unable to update Funding Source labels",
 				Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), ID),
 			})
 			return diags

--- a/kion/resource_ou.go
+++ b/kion/resource_ou.go
@@ -122,7 +122,7 @@ func resourceOUCreate(ctx context.Context, d *schema.ResourceData, m interface{}
 
 	d.SetId(strconv.Itoa(resp.RecordID))
 
-	if d.Get("labels") != nil {
+	if labels, ok := d.GetOk("labels"); ok && labels != nil {
 		ID := d.Id()
 		err = hc.PutAppLabelIDs(client, hc.FlattenAssociateLabels(d, "labels"), "ou", ID)
 

--- a/kion/resource_project.go
+++ b/kion/resource_project.go
@@ -304,7 +304,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	d.SetId(strconv.Itoa(resp.RecordID))
 
-	if d.Get("labels") != nil {
+	if labels, ok := d.GetOk("labels"); ok && labels != nil {
 		ID := d.Id()
 		err = hc.PutAppLabelIDs(client, hc.FlattenAssociateLabels(d, "labels"), "project", ID)
 


### PR DESCRIPTION
# Summary

This PR addresses an issue where the provider attempts to update labels even when not defined in the HCL, leading to a `405 Method Not Allowed` error from any Kion version before `v3.7.7`. 

## Changes

1. **Label Handling Improvement**:
   - Updated the label fetching logic to use `GetOk` for better error handling and to ensure that labels are non-nil before proceeding with operations.
   - Applied this change to the following resources:
     - `resource_cloud_rule.go`
     - `resource_funding_source.go`
     - `resource_ou.go`
     - `resource_project.go`

## Details

- The existing check `if d.Get("labels") != nil` was insufficient because it might be true even if labels are not defined, as Terraform initializes the field as an empty map.
- This prevents unnecessary and problematic API calls to update labels when they are not defined in the HCL.