### PR TITLE
Getting the Terraform Registry and GitHub back in sync with `v0.3.15`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.15] - 2024-05-17
+
+- No changes.  This change was needed to get the Terraform Registry back in sync with Github.
+
 ## [0.3.14] - 2024-05-15
 
 - Fixed an issue where the provider would attempt to update project labels even when labels were not defined in the HCL. The provider now checks if labels are explicitly set and non-empty before making update requests, preventing unnecessary API calls and avoiding the `405 Method Not Allowed error` from any Kion version before v3.7.7.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This Makefile is an easy way to run common operations.
 
-VERSION=0.3.14
+VERSION=0.3.15
 
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=github.com


### PR DESCRIPTION
This PR is to get the Terraform Registry and GitHub back in sync. The `0.3.14` version in the Terraform Registry is different from the `0.3.14` version in Github because the release sent to the Terraform Registry on 5/15 wasn't pushed to the main branch of Github.  So this will allow us to get them back in sync with the `0.3.15` version.