### PR TITLE
Fix: Create named struct for AzurePolicy and add attributes to resourceAzurePolicyCreate function to satisfy Kion API's requirements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This Makefile is an easy way to run common operations.
 
-VERSION=0.3.15
+VERSION=0.3.16-dev
 
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=github.com

--- a/kion/internal/kionclient/models_azure_policy.go
+++ b/kion/internal/kionclient/models_azure_policy.go
@@ -36,16 +36,19 @@ type AzurePolicyResponse struct {
 	Status int `json:"status"`
 }
 
+// AzurePolicy for AzurePolicyCreate
+type AzurePolicy struct {
+	Description string `json:"description"`
+	Name        string `json:"name"`
+	Parameters  string `json:"parameters"`
+	Policy      string `json:"policy"`
+}
+
 // AzurePolicyCreate for: POST /api/v3/azure-policy
 type AzurePolicyCreate struct {
-	AzurePolicy struct {
-		Description string `json:"description"`
-		Name        string `json:"name"`
-		Parameters  string `json:"parameters"`
-		Policy      string `json:"policy"`
-	} `json:"azure_policy"`
-	OwnerUserGroups *[]int `json:"owner_user_groups"`
-	OwnerUsers      *[]int `json:"owner_users"`
+	AzurePolicy     AzurePolicy `json:"azure_policy"`
+	OwnerUserGroups *[]int      `json:"owner_user_groups"`
+	OwnerUsers      *[]int      `json:"owner_users"`
 }
 
 // AzurePolicyDefinitionUpdate for: PATCH /api/v3/azure-policy/{id}

--- a/kion/resource_azure_policy.go
+++ b/kion/resource_azure_policy.go
@@ -92,6 +92,12 @@ func resourceAzurePolicyCreate(ctx context.Context, d *schema.ResourceData, m in
 	client := m.(*hc.Client)
 
 	post := hc.AzurePolicyCreate{
+        AzurePolicy: hc.AzurePolicy{
+			Description: d.Get("description").(string),
+			Name:        d.Get("name").(string),
+			Parameters:  d.Get("parameters").(string),
+			Policy:      d.Get("policy").(string),
+		},
 		OwnerUserGroups: hc.FlattenGenericIDPointer(d, "owner_user_groups"),
 		OwnerUsers:      hc.FlattenGenericIDPointer(d, "owner_users"),
 	}


### PR DESCRIPTION
This is to address the issue [56](https://github.com/kionsoftware/terraform-provider-kion/issues/56) that prevented successful Azure Policy creation with the changes inside of [the PR made by @cwhall](https://github.com/kionsoftware/terraform-provider-kion/pull/59).


- This PR introduced a named struct for AzurePolicy within the AzurePolicyCreate struct
- This PR added the AzurePolicy attributes to the resourceAzurePolicyCreate function to allow Azure Policy to be created.