### PR TITLE
Add golangci-lint GitHub Action workflow and update release workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ jobs:
           cache: false
 
       - name: Run Linter
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55.2
+          version: v1.58
           args: --out-format=github-actions --issues-exit-code=1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
 
 jobs:
   golangci:
@@ -28,32 +26,5 @@ jobs:
       - name: Run Linter
         uses: golangci/golangci-lint-action@v3
         with:
-          # Require: The version of golangci-lint to use.
-          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
-          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
           version: v1.55.2
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          #
-          # Note: By default, the `.golangci.yml` file should be at the root of the repository.
-          # The location of the configuration file can be changed by using `--config=`
-          # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true, then all caching functionality will be completely disabled,
-          #           takes precedence over all other caching options.
-          # skip-cache: true
-
-          # Optional: if set to true, then the action won't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true, then the action won't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
-
-          # Optional: The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
-          # install-mode: "goinstall"
+          args: --out-format=github-actions --issues-exit-code=1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,59 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.1'
+          cache: false
+
+      - name: Run Linter
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Require: The version of golangci-lint to use.
+          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
+          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
+          version: v1.55.2
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          #
+          # Note: By default, the `.golangci.yml` file should be at the root of the repository.
+          # The location of the configuration file can be changed by using `--config=`
+          # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true, then all caching functionality will be completely disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true, then the action won't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true, then the action won't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true
+
+          # Optional: The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+          # install-mode: "goinstall"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      - '**'
 
 jobs:
   goreleaser:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,72 @@
+run:
+  timeout: 5m
+  issues-exit-code: 1
+  tests: true
+output:
+  print-issued-lines: true
+  print-linter-name: true
+linters-settings:
+  dupl:
+    threshold: 150
+  errcheck:
+    check-type-assertions: false
+    check-blank: false
+  goconst:
+    min-len: 3
+    min-occurrences: 5
+  gocyclo:
+    min-complexity: 30
+  gofmt:
+    simplify: true
+  goimports:
+    local-prefixes: https://github.com/kionsoftware/terraform-provider-kion
+  govet:
+    enable:
+      - shadow
+  lll:
+    line-length: 120
+    tab-width: 1
+  misspell:
+    locale: US
+    # ignore-words:
+    #   - cancelled
+  sloglint:
+    attr-only: true
+  unparam:
+    check-exported: false
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    # - dupl
+    - errcheck
+    - bodyclose
+    - goconst
+    - gocyclo
+    - gofmt
+    # - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    # - lll
+    - misspell
+    - sloglint
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+issues:
+  # exclude:
+  max-same-issues: 0
+  exclude-dirs:
+    - importer-script/*
+    - docs
+    - examples
+    - provider-migration-script
+    - templates
+severity:
+  default-severity: error
+  rules:
+    - linters:
+        - gofmt
+      severity: info


### PR DESCRIPTION
### Summary

This pull request introduces a new GitHub Action workflow for golangci-lint and updates the existing release workflow. 

### Changes

1. **Add golangci-lint Workflow**
   - Created `.github/workflows/golangci-lint.yml` to run golangci-lint on push and pull request events.
   - Configured to run on `master` and `main` branches for push events.
   - Utilizes `golangci/golangci-lint-action@v3` with version `v1.55.2`.

2. **Update Release Workflow**
   - Modified `.github/workflows/release.yml` to trigger only on tags with the pattern `v*`.
   - Removed branch-based triggers to streamline the release process.