### PR TITLE
Add unit tests for label resource and utility function

### DIFF
--- a/kion/internal/kionclient/helper.go
+++ b/kion/internal/kionclient/helper.go
@@ -431,3 +431,9 @@ func TestAccOUGenerateDataSourceDeclarationAll(dataSourceName, localName string)
 		data "%v" "%v" {}`, dataSourceName, localName,
 	)
 }
+
+// PrintHCLConfig prints the generated HCL configuration for unit tests.
+func PrintHCLConfig(config string) {
+	fmt.Println("Generated HCL configuration:")
+	fmt.Println(config)
+}

--- a/kion/resource_label_test.go
+++ b/kion/resource_label_test.go
@@ -31,7 +31,8 @@ var (
 
 func TestAccResourceLabelCreate(t *testing.T) {
 	config := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
-	// hc.PrintHCLConfig(config) // Print the generated HCL configuration
+	// Uncomment the following lines to print the configurations for debugging
+	// hc.PrintHCLConfig(config) // Print the generated HCL configuration for debugging
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -40,7 +41,12 @@ func TestAccResourceLabelCreate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
-				Check:  resource.ComposeTestCheckFunc(testAccLabelCheckResource(&initialTestLabel)...),
+				Check: resource.ComposeTestCheckFunc(
+					// Check that the resource was created with the expected attributes
+					resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "color", initialTestLabel.Color),
+					resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "key", initialTestLabel.Key),
+					resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "value", initialTestLabel.Value),
+				),
 			},
 		},
 	})
@@ -49,6 +55,8 @@ func TestAccResourceLabelCreate(t *testing.T) {
 func TestAccResourceLabelUpdate(t *testing.T) {
 	initialConfig := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
 	updatedConfig := testAccLabelGenerateResourceDeclaration(&updatedTestLabel)
+
+	// Uncomment the following lines to print the configurations for debugging
 	// hc.PrintHCLConfig(initialConfig) // Print the initial HCL configuration
 	// hc.PrintHCLConfig(updatedConfig) // Print the updated HCL configuration
 
@@ -58,12 +66,24 @@ func TestAccResourceLabelUpdate(t *testing.T) {
 		CheckDestroy: testAccLabelCheckResourceDestroy,
 		Steps: []resource.TestStep{
 			{
+				// Apply the initial configuration
 				Config: initialConfig,
-				Check:  resource.ComposeTestCheckFunc(testAccLabelCheckResource(&initialTestLabel)...),
+				Check: resource.ComposeTestCheckFunc(
+					// Check that the resource was created with the initial attributes
+					resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "color", initialTestLabel.Color),
+					resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "key", initialTestLabel.Key),
+					resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "value", initialTestLabel.Value),
+				),
 			},
 			{
+				// Apply the updated configuration
 				Config: updatedConfig,
-				Check:  resource.ComposeTestCheckFunc(testAccLabelCheckResource(&updatedTestLabel)...),
+				Check: resource.ComposeTestCheckFunc(
+					// Check that the resource was updated with the new attributes
+					resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "color", updatedTestLabel.Color),
+					resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "key", updatedTestLabel.Key),
+					resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "value", updatedTestLabel.Value),
+				),
 			},
 		},
 	})
@@ -71,6 +91,7 @@ func TestAccResourceLabelUpdate(t *testing.T) {
 
 func TestAccResourceLabelDelete(t *testing.T) {
 	config := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
+	// Uncomment the following lines to print the configurations for debugging
 	// hc.PrintHCLConfig(config) // Print the generated HCL configuration
 
 	resource.Test(t, resource.TestCase{

--- a/kion/resource_label_test.go
+++ b/kion/resource_label_test.go
@@ -49,8 +49,8 @@ func TestAccResourceLabelCreate(t *testing.T) {
 func TestAccResourceLabelUpdate(t *testing.T) {
 	initialConfig := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
 	updatedConfig := testAccLabelGenerateResourceDeclaration(&updatedTestLabel)
-	hc.PrintHCLConfig(initialConfig) // Print the initial HCL configuration
-	hc.PrintHCLConfig(updatedConfig) // Print the updated HCL configuration
+	// hc.PrintHCLConfig(initialConfig) // Print the initial HCL configuration
+	// hc.PrintHCLConfig(updatedConfig) // Print the updated HCL configuration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/kion/resource_label_test.go
+++ b/kion/resource_label_test.go
@@ -1,0 +1,167 @@
+package kion
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	hc "github.com/kionsoftware/terraform-provider-kion/kion/internal/kionclient"
+)
+
+const (
+	resourceTypeLabel = "kion_label"
+	resourceNameLabel = "label1"
+)
+
+var (
+	initialTestLabel = hc.LabelCreate{
+		Color: "#123abc",
+		Key:   "environment",
+		Value: "production",
+	}
+	updatedTestLabel = hc.LabelCreate{
+		Color: "#abcdef",
+		Key:   "env",
+		Value: "prod",
+	}
+)
+
+func TestAccResourceLabelCreate(t *testing.T) {
+	config := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
+	printHCLConfig(config) // Print the generated HCL configuration
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccLabelCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  resource.ComposeTestCheckFunc(testAccLabelCheckResource(&initialTestLabel)...),
+			},
+		},
+	})
+}
+
+func TestAccResourceLabelUpdate(t *testing.T) {
+	initialConfig := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
+	updatedConfig := testAccLabelGenerateResourceDeclaration(&updatedTestLabel)
+	printHCLConfig(initialConfig) // Print the initial HCL configuration
+	printHCLConfig(updatedConfig) // Print the updated HCL configuration
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccLabelCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check:  resource.ComposeTestCheckFunc(testAccLabelCheckResource(&initialTestLabel)...),
+			},
+			{
+				Config: updatedConfig,
+				Check:  resource.ComposeTestCheckFunc(testAccLabelCheckResource(&updatedTestLabel)...),
+			},
+		},
+	})
+}
+
+func TestAccResourceLabelDelete(t *testing.T) {
+	config := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
+	printHCLConfig(config) // Print the generated HCL configuration
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccLabelCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  resource.ComposeTestCheckFunc(testAccLabelCheckResource(&initialTestLabel)...),
+			},
+			{
+				Config:       "", // Apply an empty configuration to delete the resource
+				RefreshState: true,
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						// Ensure the resource is removed from the state
+						for _, rs := range s.RootModule().Resources {
+							if rs.Type == resourceTypeLabel {
+								return fmt.Errorf("expected no resources, found %s", rs.Primary.ID)
+							}
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func printHCLConfig(config string) {
+	fmt.Println("Generated HCL configuration:")
+	fmt.Println(config)
+}
+
+// testAccLabelCheckResource returns a slice of functions that validate the test resource's fields
+func testAccLabelCheckResource(label *hc.LabelCreate) (funcs []resource.TestCheckFunc) {
+	funcs = []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "color", label.Color),
+		resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "key", label.Key),
+		resource.TestCheckResourceAttr(resourceTypeLabel+"."+resourceNameLabel, "value", label.Value),
+	}
+	return
+}
+
+// testAccLabelGenerateResourceDeclaration generates a resource declaration string (a la main.tf)
+func testAccLabelGenerateResourceDeclaration(label *hc.LabelCreate) string {
+	if label == nil {
+		return ""
+	}
+
+	return fmt.Sprintf(`
+		resource "%v" "%v" {
+			color = "%v"
+			key   = "%v"
+			value = "%v"
+		}`,
+		resourceTypeLabel, resourceNameLabel,
+		label.Color,
+		label.Key,
+		label.Value,
+	)
+}
+
+// testAccLabelCheckResourceDestroy verifies the resource has been destroyed
+func testAccLabelCheckResourceDestroy(s *terraform.State) error {
+	meta := testAccProvider.Meta()
+	if meta == nil {
+		return nil
+	}
+
+	client := meta.(*hc.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != resourceTypeLabel {
+			continue
+		}
+
+		resp := new(hc.LabelResponse)
+		err := client.GET(fmt.Sprintf("/v3/label/%s", rs.Primary.ID), resp)
+		if err == nil {
+			if fmt.Sprint(resp.Data.ID) == rs.Primary.ID {
+				return fmt.Errorf("Label (%s) still exists.", rs.Primary.ID)
+			}
+			return nil
+		}
+
+		if !strings.Contains(err.Error(), fmt.Sprintf("status: %d", http.StatusNotFound)) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/kion/resource_label_test.go
+++ b/kion/resource_label_test.go
@@ -31,7 +31,7 @@ var (
 
 func TestAccResourceLabelCreate(t *testing.T) {
 	config := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
-	printHCLConfig(config) // Print the generated HCL configuration
+	hc.PrintHCLConfig(config) // Print the generated HCL configuration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -49,8 +49,8 @@ func TestAccResourceLabelCreate(t *testing.T) {
 func TestAccResourceLabelUpdate(t *testing.T) {
 	initialConfig := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
 	updatedConfig := testAccLabelGenerateResourceDeclaration(&updatedTestLabel)
-	printHCLConfig(initialConfig) // Print the initial HCL configuration
-	printHCLConfig(updatedConfig) // Print the updated HCL configuration
+	hc.PrintHCLConfig(initialConfig) // Print the initial HCL configuration
+	hc.PrintHCLConfig(updatedConfig) // Print the updated HCL configuration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -71,7 +71,7 @@ func TestAccResourceLabelUpdate(t *testing.T) {
 
 func TestAccResourceLabelDelete(t *testing.T) {
 	config := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
-	printHCLConfig(config) // Print the generated HCL configuration
+	hc.PrintHCLConfig(config) // Print the generated HCL configuration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -99,11 +99,6 @@ func TestAccResourceLabelDelete(t *testing.T) {
 			},
 		},
 	})
-}
-
-func printHCLConfig(config string) {
-	fmt.Println("Generated HCL configuration:")
-	fmt.Println(config)
 }
 
 // testAccLabelCheckResource returns a slice of functions that validate the test resource's fields

--- a/kion/resource_label_test.go
+++ b/kion/resource_label_test.go
@@ -31,7 +31,7 @@ var (
 
 func TestAccResourceLabelCreate(t *testing.T) {
 	config := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
-	hc.PrintHCLConfig(config) // Print the generated HCL configuration
+	// hc.PrintHCLConfig(config) // Print the generated HCL configuration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -71,7 +71,7 @@ func TestAccResourceLabelUpdate(t *testing.T) {
 
 func TestAccResourceLabelDelete(t *testing.T) {
 	config := testAccLabelGenerateResourceDeclaration(&initialTestLabel)
-	hc.PrintHCLConfig(config) // Print the generated HCL configuration
+	// hc.PrintHCLConfig(config) // Print the generated HCL configuration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
### Add unit tests for label resource and utility function

#### Added
- Implemented `PrintHCLConfig` function in `helper.go` to print generated HCL configuration for unit tests.
- Created `resource_label_test.go` with the following tests for `kion_label` resource:
  - `TestAccResourceLabelCreate` to test the creation of a label resource.
  - `TestAccResourceLabelUpdate` to test the updating of a label resource.
  - `TestAccResourceLabelDelete` to test the deletion of a label resource.
