### PR TITLE
fix(azure_policy): Add support for Adding New Azure Policies

### DIFF
--- a/kion/internal/kionclient/helper.go
+++ b/kion/internal/kionclient/helper.go
@@ -431,3 +431,9 @@ func TestAccOUGenerateDataSourceDeclarationAll(dataSourceName, localName string)
 		data "%v" "%v" {}`, dataSourceName, localName,
 	)
 }
+
+// PrintHCLConfig prints the generated HCL configuration for unit tests.
+func PrintHCLConfig(config string) {
+	fmt.Println("Generated HCL configuration:")
+	fmt.Println(config)
+}

--- a/kion/internal/kionclient/models_azure_policy.go
+++ b/kion/internal/kionclient/models_azure_policy.go
@@ -36,16 +36,19 @@ type AzurePolicyResponse struct {
 	Status int `json:"status"`
 }
 
+// AzurePolicy for AzurePolicyCreate
+type AzurePolicy struct {
+	Description string `json:"description"`
+	Name        string `json:"name"`
+	Parameters  string `json:"parameters"`
+	Policy      string `json:"policy"`
+}
+
 // AzurePolicyCreate for: POST /api/v3/azure-policy
 type AzurePolicyCreate struct {
-	AzurePolicy struct {
-		Description string `json:"description"`
-		Name        string `json:"name"`
-		Parameters  string `json:"parameters"`
-		Policy      string `json:"policy"`
-	} `json:"azure_policy"`
-	OwnerUserGroups *[]int `json:"owner_user_groups"`
-	OwnerUsers      *[]int `json:"owner_users"`
+	AzurePolicy     AzurePolicy `json:"azure_policy"`
+	OwnerUserGroups *[]int      `json:"owner_user_groups"`
+	OwnerUsers      *[]int      `json:"owner_users"`
 }
 
 // AzurePolicyDefinitionUpdate for: PATCH /api/v3/azure-policy/{id}

--- a/kion/resource_azure_policy.go
+++ b/kion/resource_azure_policy.go
@@ -92,6 +92,12 @@ func resourceAzurePolicyCreate(ctx context.Context, d *schema.ResourceData, m in
 	client := m.(*hc.Client)
 
 	post := hc.AzurePolicyCreate{
+		AzurePolicy: hc.AzurePolicy{
+			Description: d.Get("description").(string),
+			Name:        d.Get("name").(string),
+			Parameters:  d.Get("parameters").(string),
+			Policy:      d.Get("policy").(string),
+		},
 		OwnerUserGroups: hc.FlattenGenericIDPointer(d, "owner_user_groups"),
 		OwnerUsers:      hc.FlattenGenericIDPointer(d, "owner_users"),
 	}
@@ -240,7 +246,14 @@ func resourceAzurePolicyUpdate(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	if hasChanged > 0 {
-		d.Set("last_updated", time.Now().Format(time.RFC850))
+		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Failed to set last_updated",
+				Detail:   err.Error(),
+			})
+			return diags
+		}
 	}
 
 	return resourceAzurePolicyRead(ctx, d, m)

--- a/kion/resource_azure_policy_test.go
+++ b/kion/resource_azure_policy_test.go
@@ -51,7 +51,8 @@ var (
 
 func TestAccResourceAzurePolicyCreate(t *testing.T) {
 	config := testAccAzurePolicyGenerateResourceDeclaration(&initialTestAzurePolicy)
-	hc.PrintHCLConfig(config) // Print the generated HCL configuration
+	// Uncomment the following lines to print the configurations for debugging
+	// hc.PrintHCLConfig(config) // Print the generated HCL configuration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -69,8 +70,9 @@ func TestAccResourceAzurePolicyCreate(t *testing.T) {
 func TestAccResourceAzurePolicyUpdate(t *testing.T) {
 	initialConfig := testAccAzurePolicyGenerateResourceDeclaration(&initialTestAzurePolicy)
 	updatedConfig := testAccAzurePolicyGenerateResourceDeclaration(&updatedTestAzurePolicy)
-	hc.PrintHCLConfig(initialConfig) // Print the initial HCL configuration
-	hc.PrintHCLConfig(updatedConfig) // Print the updated HCL configuration
+	// Uncomment the following lines to print the configurations for debugging
+	// hc.PrintHCLConfig(initialConfig) // Print the initial HCL configuration
+	// hc.PrintHCLConfig(updatedConfig) // Print the updated HCL configuration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -91,7 +93,8 @@ func TestAccResourceAzurePolicyUpdate(t *testing.T) {
 
 func TestAccResourceAzurePolicyDelete(t *testing.T) {
 	config := testAccAzurePolicyGenerateResourceDeclaration(&initialTestAzurePolicy)
-	hc.PrintHCLConfig(config) // Print the generated HCL configuration
+	// Uncomment the following lines to print the configurations for debugging
+	// hc.PrintHCLConfig(config) // Print the generated HCL configuration // Print the generated HCL configuration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/kion/resource_azure_policy_test.go
+++ b/kion/resource_azure_policy_test.go
@@ -1,0 +1,197 @@
+package kion
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	hc "github.com/kionsoftware/terraform-provider-kion/kion/internal/kionclient"
+)
+
+const (
+	resourceTypeAzurePolicy = "kion_azure_policy"
+	resourceNameAzurePolicy = "azure_policy1"
+)
+
+var (
+	initialTestAzurePolicy = hc.AzurePolicyCreate{
+		AzurePolicy: struct {
+			Description string `json:"description"`
+			Name        string `json:"name"`
+			Parameters  string `json:"parameters"`
+			Policy      string `json:"policy"`
+		}{
+			Description: "Initial description",
+			Name:        "Initial Policy",
+			Parameters:  "{}",
+			Policy:      "{}",
+		},
+		OwnerUserGroups: &[]int{1},
+		OwnerUsers:      &[]int{1},
+	}
+	updatedTestAzurePolicy = hc.AzurePolicyCreate{
+		AzurePolicy: struct {
+			Description string `json:"description"`
+			Name        string `json:"name"`
+			Parameters  string `json:"parameters"`
+			Policy      string `json:"policy"`
+		}{
+			Description: "Updated description",
+			Name:        "Updated Policy",
+			Parameters:  "{\"param\":\"value\"}",
+			Policy:      "{\"rule\":\"new_rule\"}",
+		},
+		OwnerUserGroups: &[]int{2},
+		OwnerUsers:      &[]int{2},
+	}
+)
+
+func TestAccResourceAzurePolicyCreate(t *testing.T) {
+	config := testAccAzurePolicyGenerateResourceDeclaration(&initialTestAzurePolicy)
+	hc.PrintHCLConfig(config) // Print the generated HCL configuration
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAzurePolicyCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  resource.ComposeTestCheckFunc(testAccAzurePolicyCheckResource(&initialTestAzurePolicy)...),
+			},
+		},
+	})
+}
+
+func TestAccResourceAzurePolicyUpdate(t *testing.T) {
+	initialConfig := testAccAzurePolicyGenerateResourceDeclaration(&initialTestAzurePolicy)
+	updatedConfig := testAccAzurePolicyGenerateResourceDeclaration(&updatedTestAzurePolicy)
+	hc.PrintHCLConfig(initialConfig) // Print the initial HCL configuration
+	hc.PrintHCLConfig(updatedConfig) // Print the updated HCL configuration
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAzurePolicyCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check:  resource.ComposeTestCheckFunc(testAccAzurePolicyCheckResource(&initialTestAzurePolicy)...),
+			},
+			{
+				Config: updatedConfig,
+				Check:  resource.ComposeTestCheckFunc(testAccAzurePolicyCheckResource(&updatedTestAzurePolicy)...),
+			},
+		},
+	})
+}
+
+func TestAccResourceAzurePolicyDelete(t *testing.T) {
+	config := testAccAzurePolicyGenerateResourceDeclaration(&initialTestAzurePolicy)
+	hc.PrintHCLConfig(config) // Print the generated HCL configuration
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAzurePolicyCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  resource.ComposeTestCheckFunc(testAccAzurePolicyCheckResource(&initialTestAzurePolicy)...),
+			},
+			{
+				Config:       "", // Apply an empty configuration to delete the resource
+				RefreshState: true,
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						// Ensure the resource is removed from the state
+						for _, rs := range s.RootModule().Resources {
+							if rs.Type == resourceTypeAzurePolicy {
+								return fmt.Errorf("expected no resources, found %s", rs.Primary.ID)
+							}
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// testAccAzurePolicyCheckResource returns a slice of functions that validate the test resource's fields
+func testAccAzurePolicyCheckResource(policy *hc.AzurePolicyCreate) (funcs []resource.TestCheckFunc) {
+	funcs = []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceTypeAzurePolicy+"."+resourceNameAzurePolicy, "description", policy.AzurePolicy.Description),
+		resource.TestCheckResourceAttr(resourceTypeAzurePolicy+"."+resourceNameAzurePolicy, "name", policy.AzurePolicy.Name),
+		resource.TestCheckResourceAttr(resourceTypeAzurePolicy+"."+resourceNameAzurePolicy, "parameters", policy.AzurePolicy.Parameters),
+		resource.TestCheckResourceAttr(resourceTypeAzurePolicy+"."+resourceNameAzurePolicy, "policy", policy.AzurePolicy.Policy),
+	}
+	return
+}
+
+// testAccAzurePolicyGenerateResourceDeclaration generates a resource declaration string (a la main.tf)
+func testAccAzurePolicyGenerateResourceDeclaration(policy *hc.AzurePolicyCreate) string {
+	if policy == nil {
+		return ""
+	}
+
+	return fmt.Sprintf(`
+		resource "%v" "%v" {
+			description = "%v"
+			name        = "%v"
+			parameters  = "%v"
+			policy      = "%v"
+			owner_user_groups = [%v]
+			owner_users = [%v]
+		}`,
+		resourceTypeAzurePolicy, resourceNameAzurePolicy,
+		policy.AzurePolicy.Description,
+		policy.AzurePolicy.Name,
+		policy.AzurePolicy.Parameters,
+		policy.AzurePolicy.Policy,
+		strings.Join(intSliceToStringSlice(*policy.OwnerUserGroups), ","),
+		strings.Join(intSliceToStringSlice(*policy.OwnerUsers), ","),
+	)
+}
+
+// testAccAzurePolicyCheckResourceDestroy verifies the resource has been destroyed
+func testAccAzurePolicyCheckResourceDestroy(s *terraform.State) error {
+	meta := testAccProvider.Meta()
+	if meta == nil {
+		return nil
+	}
+
+	client := meta.(*hc.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != resourceTypeAzurePolicy {
+			continue
+		}
+
+		resp := new(hc.AzurePolicyResponse)
+		err := client.GET(fmt.Sprintf("/v3/azure-policy/%s", rs.Primary.ID), resp)
+		if err == nil {
+			if fmt.Sprint(resp.Data.AzurePolicy.ID) == rs.Primary.ID {
+				return fmt.Errorf("Azure Policy (%s) still exists.", rs.Primary.ID)
+			}
+			return nil
+		}
+
+		if !strings.Contains(err.Error(), fmt.Sprintf("status: %d", http.StatusNotFound)) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func intSliceToStringSlice(intSlice []int) []string {
+	strSlice := make([]string, len(intSlice))
+	for i, val := range intSlice {
+		strSlice[i] = fmt.Sprintf("%d", val)
+	}
+	return strSlice
+}


### PR DESCRIPTION
### Added

- Added support for creating Azure Policies:
  - Introduced a new `AzurePolicy` struct to encapsulate policy details.
  - Implemented unit tests for Azure Policy resource creation, update, and deletion.

### Changed

- Refactored the `AzurePolicyCreate` struct to use the new `AzurePolicy` struct.
- Updated `resourceAzurePolicyCreate` and `resourceAzurePolicyUpdate` functions to accommodate the new `AzurePolicy` struct.
- Improved error handling in the `resourceAzurePolicyUpdate` function when setting the `last_updated` attribute.

### Associated Issue
https://github.com/kionsoftware/terraform-provider-kion/issues/56