### PR TITLE
Added GCP IAM Roles to Cloud Access Roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This Makefile is an easy way to run common operations.
 
-VERSION=0.3.15
+VERSION=0.3.16-dev
 
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=github.com

--- a/docs/resources/ou_cloud_access_role.md
+++ b/docs/resources/ou_cloud_access_role.md
@@ -48,6 +48,7 @@ output "ou_car_id" {
 - `aws_iam_permissions_boundary` (Number)
 - `aws_iam_policies` (Block Set) (see [below for nested schema](#nestedblock--aws_iam_policies))
 - `azure_role_definitions` (Block Set) (see [below for nested schema](#nestedblock--azure_role_definitions))
+- `gcp_iam_roles` (Block Set) (see [below for nested schema](#nestedblock--gcp_iam_roles))
 - `last_updated` (String)
 - `long_term_access_keys` (Boolean)
 - `short_term_access_keys` (Boolean)
@@ -69,6 +70,14 @@ Read-Only:
 
 <a id="nestedblock--azure_role_definitions"></a>
 ### Nested Schema for `azure_role_definitions`
+
+Read-Only:
+
+- `id` (Number) The ID of this resource.
+
+
+<a id="nestedblock--gcp_iam_roles"></a>
+### Nested Schema for `gcp_iam_roles`
 
 Read-Only:
 

--- a/docs/resources/project_cloud_access_role.md
+++ b/docs/resources/project_cloud_access_role.md
@@ -52,6 +52,7 @@ output "project_car_id" {
 - `aws_iam_policies` (Block Set) (see [below for nested schema](#nestedblock--aws_iam_policies))
 - `azure_role_definitions` (Block Set) (see [below for nested schema](#nestedblock--azure_role_definitions))
 - `future_accounts` (Boolean)
+- `gcp_iam_roles` (Block Set) (see [below for nested schema](#nestedblock--gcp_iam_roles))
 - `last_updated` (String)
 - `long_term_access_keys` (Boolean)
 - `short_term_access_keys` (Boolean)
@@ -81,6 +82,14 @@ Read-Only:
 
 <a id="nestedblock--azure_role_definitions"></a>
 ### Nested Schema for `azure_role_definitions`
+
+Read-Only:
+
+- `id` (Number) The ID of this resource.
+
+
+<a id="nestedblock--gcp_iam_roles"></a>
+### Nested Schema for `gcp_iam_roles`
 
 Read-Only:
 

--- a/kion/internal/kionclient/helper.go
+++ b/kion/internal/kionclient/helper.go
@@ -175,31 +175,42 @@ func FlattenAssociateLabels(d *schema.ResourceData, key string) *[]AssociateLabe
 	return &labels
 }
 
-// InflateObjectWithID -
+// InflateObjectWithID takes a slice of ObjectWithID and converts it into a slice of maps,
+// where each map contains the ID of an ObjectWithID. If the input slice is nil, it returns an empty slice.
 func InflateObjectWithID(arr []ObjectWithID) []interface{} {
 	if arr != nil {
+		// Create an empty slice to hold the converted items
 		final := make([]interface{}, 0)
 
+		// Iterate over each item in the input slice
 		for _, item := range arr {
+			// Create a map to hold the item data
 			it := make(map[string]interface{})
 
+			// Add the ID to the map
 			it["id"] = item.ID
 
+			// Append the map to the final slice
 			final = append(final, it)
 		}
 
+		// Return the final slice of maps
 		return final
 	}
 
+	// Return an empty slice if the input is nil
 	return make([]interface{}, 0)
 }
 
-// InflateSingleObjectWithID -
+// InflateSingleObjectWithID takes a pointer to an ObjectWithID and returns its ID.
+// If the input is nil, it returns nil.
 func InflateSingleObjectWithID(single *ObjectWithID) interface{} {
 	if single != nil {
+		// Return the ID of the non-nil ObjectWithID
 		return single.ID
 	}
 
+	// Return nil if the input is nil
 	return nil
 }
 

--- a/kion/internal/kionclient/models_ou_cloud_access_role.go
+++ b/kion/internal/kionclient/models_ou_cloud_access_role.go
@@ -6,6 +6,7 @@ type OUCloudAccessRoleResponse struct {
 		AwsIamPermissionsBoundary *ObjectWithID  `json:"aws_iam_permissions_boundary"`
 		AwsIamPolicies            []ObjectWithID `json:"aws_iam_policies"`
 		AzureRoleDefinitions      []ObjectWithID `json:"azure_role_definitions"`
+		GCPIamRoles               []ObjectWithID `json:"gcp_iam_roles"`
 		OUCloudAccessRole         struct {
 			AwsIamPath          string `json:"aws_iam_path"`
 			AwsIamRoleName      string `json:"aws_iam_role_name"`
@@ -29,6 +30,7 @@ type OUCloudAccessRoleCreate struct {
 	AwsIamPolicies            *[]int `json:"aws_iam_policies"`
 	AwsIamRoleName            string `json:"aws_iam_role_name"`
 	AzureRoleDefinitions      *[]int `json:"azure_role_definitions"`
+	GCPIamRoles               *[]int `json:"gcp_iam_roles"`
 	LongTermAccessKeys        bool   `json:"long_term_access_keys"`
 	Name                      string `json:"name"`
 	OUID                      int    `json:"ou_id"`
@@ -51,6 +53,7 @@ type OUCloudAccessRoleAssociationsAdd struct {
 	AwsIamPermissionsBoundary *int   `json:"aws_iam_permissions_boundary"`
 	AwsIamPolicies            *[]int `json:"aws_iam_policies"`
 	AzureRoleDefinitions      *[]int `json:"azure_role_definitions"`
+	GCPIamRoles               *[]int `json:"gcp_iam_roles"`
 	UserGroupIds              *[]int `json:"user_group_ids"`
 	UserIds                   *[]int `json:"user_ids"`
 }
@@ -60,6 +63,7 @@ type OUCloudAccessRoleAssociationsRemove struct {
 	AwsIamPermissionsBoundary *int   `json:"aws_iam_permissions_boundary"`
 	AwsIamPolicies            *[]int `json:"aws_iam_policies"`
 	AzureRoleDefinitions      *[]int `json:"azure_role_definitions"`
+	GCPIamRoles               *[]int `json:"gcp_iam_roles"`
 	UserGroupIds              *[]int `json:"user_group_ids"`
 	UserIds                   *[]int `json:"user_ids"`
 }

--- a/kion/internal/kionclient/models_project_cloud_access_role.go
+++ b/kion/internal/kionclient/models_project_cloud_access_role.go
@@ -7,6 +7,7 @@ type ProjectCloudAccessRoleResponse struct {
 		AwsIamPermissionsBoundary *ObjectWithID  `json:"aws_iam_permissions_boundary"`
 		AwsIamPolicies            []ObjectWithID `json:"aws_iam_policies"`
 		AzureRoleDefinitions      []ObjectWithID `json:"azure_role_definitions"`
+		GCPIamRoles               []ObjectWithID `json:"gcp_iam_roles"`
 		ProjectCloudAccessRole    struct {
 			ApplyToAllAccounts  bool   `json:"apply_to_all_accounts"`
 			AwsIamPath          string `json:"aws_iam_path"`
@@ -35,6 +36,7 @@ type ProjectCloudAccessRoleCreate struct {
 	AwsIamRoleName            string `json:"aws_iam_role_name"`
 	AzureRoleDefinitions      *[]int `json:"azure_role_definitions"`
 	FutureAccounts            bool   `json:"future_accounts"`
+	GCPIamRoles               *[]int `json:"gcp_iam_roles"`
 	LongTermAccessKeys        bool   `json:"long_term_access_keys"`
 	Name                      string `json:"name"`
 	ProjectID                 int    `json:"project_id"`
@@ -60,6 +62,7 @@ type ProjectCloudAccessRoleAssociationsAdd struct {
 	AwsIamPermissionsBoundary *int   `json:"aws_iam_permissions_boundary"`
 	AwsIamPolicies            *[]int `json:"aws_iam_policies"`
 	AzureRoleDefinitions      *[]int `json:"azure_role_definitions"`
+	GCPIamRoles               *[]int `json:"gcp_iam_roles"`
 	UserGroupIds              *[]int `json:"user_group_ids"`
 	UserIds                   *[]int `json:"user_ids"`
 }
@@ -70,6 +73,7 @@ type ProjectCloudAccessRoleAssociationsRemove struct {
 	AwsIamPermissionsBoundary *int   `json:"aws_iam_permissions_boundary"`
 	AwsIamPolicies            *[]int `json:"aws_iam_policies"`
 	AzureRoleDefinitions      *[]int `json:"azure_role_definitions"`
+	GCPIamRoles               *[]int `json:"gcp_iam_roles"`
 	UserGroupIds              *[]int `json:"user_group_ids"`
 	UserIds                   *[]int `json:"user_ids"`
 }

--- a/kion/resource_ou_cloud_access_role.go
+++ b/kion/resource_ou_cloud_access_role.go
@@ -134,6 +134,7 @@ func resourceOUCloudAccessRoleCreate(ctx context.Context, d *schema.ResourceData
 	var diags diag.Diagnostics
 	client := m.(*hc.Client)
 
+	// Create the request payload
 	post := hc.OUCloudAccessRoleCreate{
 		AwsIamPath:                d.Get("aws_iam_path").(string),
 		AwsIamPermissionsBoundary: hc.FlattenIntPointer(d, "aws_iam_permissions_boundary"),
@@ -150,26 +151,31 @@ func resourceOUCloudAccessRoleCreate(ctx context.Context, d *schema.ResourceData
 		WebAccess:                 d.Get("web_access").(bool),
 	}
 
+	// Send the POST request
 	resp, err := client.POST("/v3/ou-cloud-access-role", post)
 	if err != nil {
-		diags = append(diags, diag.Diagnostic{
+		return append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create OUCloudAccessRole",
-			Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), post),
+			Detail:   fmt.Sprintf("Error: %v\nItem: %v", err, post),
 		})
-		return diags
-	} else if resp.RecordID == 0 {
-		diags = append(diags, diag.Diagnostic{
+	}
+
+	if resp.RecordID == 0 {
+		return append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create OUCloudAccessRole",
 			Detail:   fmt.Sprintf("Error: %v\nItem: %v", errors.New("received item ID of 0"), post),
 		})
-		return diags
 	}
 
+	// Set the ID for the created resource
 	d.SetId(strconv.Itoa(resp.RecordID))
 
-	resourceOUCloudAccessRoleRead(ctx, d, m)
+	// Read the resource to update the state
+	if readDiags := resourceOUCloudAccessRoleRead(ctx, d, m); readDiags.HasError() {
+		diags = append(diags, readDiags...)
+	}
 
 	return diags
 }
@@ -191,32 +197,20 @@ func resourceOUCloudAccessRoleRead(ctx context.Context, d *schema.ResourceData, 
 	}
 	item := resp.Data
 
-	data := make(map[string]interface{})
-	data["aws_iam_path"] = item.OUCloudAccessRole.AwsIamPath
-	if hc.InflateSingleObjectWithID(item.AwsIamPermissionsBoundary) != nil {
-		data["aws_iam_permissions_boundary"] = hc.InflateSingleObjectWithID(item.AwsIamPermissionsBoundary)
+	data := map[string]interface{}{
+		"aws_iam_path":                 item.OUCloudAccessRole.AwsIamPath,
+		"aws_iam_role_name":            item.OUCloudAccessRole.AwsIamRoleName,
+		"aws_iam_permissions_boundary": hc.InflateSingleObjectWithID(item.AwsIamPermissionsBoundary),
+		"long_term_access_keys":        item.OUCloudAccessRole.LongTermAccessKeys,
+		"name":                         item.OUCloudAccessRole.Name,
+		"ou_id":                        item.OUCloudAccessRole.OUID,
+		"short_term_access_keys":       item.OUCloudAccessRole.ShortTermAccessKeys,
+		"web_access":                   item.OUCloudAccessRole.WebAccess,
+		"aws_iam_policies":             hc.InflateObjectWithID(item.AwsIamPolicies),
+		"azure_role_definitions":       hc.InflateObjectWithID(item.AzureRoleDefinitions),
+		"gcp_iam_roles":                hc.InflateObjectWithID(item.GCPIamRoles),
+		"users":                        hc.InflateObjectWithID(item.Users),
 	}
-	if hc.InflateObjectWithID(item.AwsIamPolicies) != nil {
-		data["aws_iam_policies"] = hc.InflateObjectWithID(item.AwsIamPolicies)
-	}
-	data["aws_iam_role_name"] = item.OUCloudAccessRole.AwsIamRoleName
-	if hc.InflateObjectWithID(item.AzureRoleDefinitions) != nil {
-		data["azure_role_definitions"] = hc.InflateObjectWithID(item.AzureRoleDefinitions)
-	}
-	if hc.InflateObjectWithID(item.GCPIamRoles) != nil {
-		data["gcp_iam_roles"] = hc.InflateObjectWithID(item.GCPIamRoles)
-	}
-	data["long_term_access_keys"] = item.OUCloudAccessRole.LongTermAccessKeys
-	data["name"] = item.OUCloudAccessRole.Name
-	data["ou_id"] = item.OUCloudAccessRole.OUID
-	data["short_term_access_keys"] = item.OUCloudAccessRole.ShortTermAccessKeys
-	if hc.InflateObjectWithID(item.UserGroups) != nil {
-		data["user_groups"] = hc.InflateObjectWithID(item.UserGroups)
-	}
-	if hc.InflateObjectWithID(item.Users) != nil {
-		data["users"] = hc.InflateObjectWithID(item.Users)
-	}
-	data["web_access"] = item.OUCloudAccessRole.WebAccess
 
 	for k, v := range data {
 		if err := d.Set(k, v); err != nil {
@@ -237,17 +231,14 @@ func resourceOUCloudAccessRoleUpdate(ctx context.Context, d *schema.ResourceData
 	client := m.(*hc.Client)
 	ID := d.Id()
 
-	hasChanged := 0
+	var hasChanged bool
 
 	// Determine if the attributes that are updatable are changed.
 	// Leave out fields that are not allowed to be changed like
 	// `aws_iam_path` in AWS IAM policies and add `ForceNew: true` to the
 	// schema instead.
-	if d.HasChanges("long_term_access_keys",
-		"name",
-		"short_term_access_keys",
-		"web_access") {
-		hasChanged++
+	if d.HasChanges("long_term_access_keys", "name", "short_term_access_keys", "web_access") {
+		hasChanged = true
 		req := hc.OUCloudAccessRoleUpdate{
 			LongTermAccessKeys:  d.Get("long_term_access_keys").(bool),
 			Name:                d.Get("name").(string),
@@ -255,8 +246,7 @@ func resourceOUCloudAccessRoleUpdate(ctx context.Context, d *schema.ResourceData
 			WebAccess:           d.Get("web_access").(bool),
 		}
 
-		err := client.PATCH(fmt.Sprintf("/v3/ou-cloud-access-role/%s", ID), req)
-		if err != nil {
+		if err := client.PATCH(fmt.Sprintf("/v3/ou-cloud-access-role/%s", ID), req); err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update OUCloudAccessRole",
@@ -267,35 +257,44 @@ func resourceOUCloudAccessRoleUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	// Handle associations.
-	if d.HasChanges("aws_iam_permissions_boundary",
-		"aws_iam_policies",
-		"azure_role_definitions",
-		"gcp_iam_roles",
-		"user_groups",
-		"users") {
-		hasChanged++
-		arrAddAwsIamPermissionsBoundary, arrRemoveAwsIamPermissionsBoundary, _, _ := hc.AssociationChangedInt(d, "aws_iam_permissions_boundary")
-		arrAddAwsIamPolicies, arrRemoveAwsIamPolicies, _, _ := hc.AssociationChanged(d, "aws_iam_policies")
-		arrAddAzureRoleDefinitions, arrRemoveAzureRoleDefinitions, _, _ := hc.AssociationChanged(d, "azure_role_definitions")
-		arrAddGCPIamRoles, arrRemoveGCPIamRoles, _, _ := hc.AssociationChanged(d, "gcp_iam_roles")
-		arrAddUserGroupIds, arrRemoveUserGroupIds, _, _ := hc.AssociationChanged(d, "user_groups")
-		arrAddUserIds, arrRemoveUserIds, _, _ := hc.AssociationChanged(d, "users")
+	if d.HasChanges("aws_iam_permissions_boundary", "aws_iam_policies", "azure_role_definitions", "gcp_iam_roles", "user_groups", "users") {
+		hasChanged = true
 
-		if arrAddAwsIamPermissionsBoundary != nil ||
-			len(arrAddAwsIamPolicies) > 0 ||
-			len(arrAddUserGroupIds) > 0 ||
-			len(arrAddAzureRoleDefinitions) > 0 ||
-			len(arrAddGCPIamRoles) > 0 ||
-			len(arrAddUserIds) > 0 {
-			_, err := client.POST(fmt.Sprintf("/v3/ou-cloud-access-role/%s/association", ID), hc.OUCloudAccessRoleAssociationsAdd{
-				AwsIamPermissionsBoundary: arrAddAwsIamPermissionsBoundary,
-				AwsIamPolicies:            &arrAddAwsIamPolicies,
-				AzureRoleDefinitions:      &arrAddAzureRoleDefinitions,
-				GCPIamRoles:               &arrAddGCPIamRoles,
-				UserGroupIds:              &arrAddUserGroupIds,
-				UserIds:                   &arrAddUserIds,
-			})
-			if err != nil {
+		var addCarAssociation hc.OUCloudAccessRoleAssociationsAdd
+		var removeCarAssociation hc.OUCloudAccessRoleAssociationsRemove
+
+		if addBoundary, removeBoundary, _, _ := hc.AssociationChangedInt(d, "aws_iam_permissions_boundary"); addBoundary != nil || removeBoundary != nil {
+			addCarAssociation.AwsIamPermissionsBoundary = addBoundary
+			removeCarAssociation.AwsIamPermissionsBoundary = removeBoundary
+		}
+
+		if arrAdd, arrRemove, _, _ := hc.AssociationChanged(d, "aws_iam_policies"); len(arrAdd) > 0 || len(arrRemove) > 0 {
+			addCarAssociation.AwsIamPolicies = &arrAdd
+			removeCarAssociation.AwsIamPolicies = &arrRemove
+		}
+
+		if arrAdd, arrRemove, _, _ := hc.AssociationChanged(d, "azure_role_definitions"); len(arrAdd) > 0 || len(arrRemove) > 0 {
+			addCarAssociation.AzureRoleDefinitions = &arrAdd
+			removeCarAssociation.AzureRoleDefinitions = &arrRemove
+		}
+
+		if arrAdd, arrRemove, _, _ := hc.AssociationChanged(d, "gcp_iam_roles"); len(arrAdd) > 0 || len(arrRemove) > 0 {
+			addCarAssociation.GCPIamRoles = &arrAdd
+			removeCarAssociation.GCPIamRoles = &arrRemove
+		}
+
+		if arrAdd, arrRemove, _, _ := hc.AssociationChanged(d, "user_groups"); len(arrAdd) > 0 || len(arrRemove) > 0 {
+			addCarAssociation.UserGroupIds = &arrAdd
+			removeCarAssociation.UserGroupIds = &arrRemove
+		}
+
+		if arrAdd, arrRemove, _, _ := hc.AssociationChanged(d, "users"); len(arrAdd) > 0 || len(arrRemove) > 0 {
+			addCarAssociation.UserIds = &arrAdd
+			removeCarAssociation.UserIds = &arrRemove
+		}
+
+		if addCarAssociation != (hc.OUCloudAccessRoleAssociationsAdd{}) {
+			if _, err := client.POST(fmt.Sprintf("/v3/ou-cloud-access-role/%s/association", ID), addCarAssociation); err != nil {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
 					Summary:  "Unable to add associations on OUCloudAccessRole",
@@ -305,24 +304,11 @@ func resourceOUCloudAccessRoleUpdate(ctx context.Context, d *schema.ResourceData
 			}
 		}
 
-		if arrRemoveAwsIamPermissionsBoundary != nil ||
-			len(arrRemoveAwsIamPolicies) > 0 ||
-			len(arrRemoveAzureRoleDefinitions) > 0 ||
-			len(arrRemoveGCPIamRoles) > 0 ||
-			len(arrRemoveUserGroupIds) > 0 ||
-			len(arrRemoveUserIds) > 0 {
-			err := client.DELETE(fmt.Sprintf("/v3/ou-cloud-access-role/%s/association", ID), hc.OUCloudAccessRoleAssociationsRemove{
-				AwsIamPermissionsBoundary: arrRemoveAwsIamPermissionsBoundary,
-				AwsIamPolicies:            &arrRemoveAwsIamPolicies,
-				AzureRoleDefinitions:      &arrRemoveAzureRoleDefinitions,
-				GCPIamRoles:               &arrRemoveGCPIamRoles,
-				UserGroupIds:              &arrRemoveUserGroupIds,
-				UserIds:                   &arrRemoveUserIds,
-			})
-			if err != nil {
+		if removeCarAssociation != (hc.OUCloudAccessRoleAssociationsRemove{}) {
+			if err := client.DELETE(fmt.Sprintf("/v3/ou-cloud-access-role/%s/association", ID), removeCarAssociation); err != nil {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
-					Summary:  "Unable to remove owners on OUCloudAccessRole",
+					Summary:  "Unable to remove associations on OUCloudAccessRole",
 					Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), ID),
 				})
 				return diags
@@ -330,7 +316,7 @@ func resourceOUCloudAccessRoleUpdate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	if hasChanged > 0 {
+	if hasChanged {
 		d.Set("last_updated", time.Now().Format(time.RFC850))
 	}
 

--- a/kion/resource_ou_cloud_access_role.go
+++ b/kion/resource_ou_cloud_access_role.go
@@ -328,18 +328,19 @@ func resourceOUCloudAccessRoleDelete(ctx context.Context, d *schema.ResourceData
 	client := m.(*hc.Client)
 	ID := d.Id()
 
+	// Make the DELETE request using the client and context
 	err := client.DELETE(fmt.Sprintf("/v3/ou-cloud-access-role/%s", ID), nil)
 	if err != nil {
+		// Add detailed diagnostic information on error
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete OUCloudAccessRole",
-			Detail:   fmt.Sprintf("Error: %v\nItem: %v", err.Error(), ID),
+			Detail:   fmt.Sprintf("Error deleting OUCloudAccessRole with ID %s: %v", ID, err),
 		})
 		return diags
 	}
 
-	// d.SetId("") is automatically called assuming delete returns no errors, but
-	// it is added here for explicitness.
+	// Explicitly clear the resource ID to indicate deletion
 	d.SetId("")
 
 	return diags


### PR DESCRIPTION
### Added

- Added `gcp_iam_roles` attribute to `ou_cloud_access_role` and `project_cloud_access_role` resources.
- Included nested schema for `gcp_iam_roles` with an `id` field in both OU and project documentation.
- Updated the models to include `GCPIamRoles` for creating, reading, updating, and deleting cloud access roles.
- Modified the create, update, and delete functions to handle `gcp_iam_roles`.

### Changed

- Refactored association handling in `resourceOUCloudAccessRoleUpdate` and `resourceProjectCloudAccessRoleUpdate` to include `gcp_iam_roles`.
- Enhanced error handling and diagnostic messages for better clarity.