### PR TITLE
v0.3.18 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Deprecated
 Removed
 Fixed
 
+## [0.3.18] - 2024-08-15
+
+## What's Changed
+
+### Fixed
+
+* Corrected a regression in the `NewFilterable` function that caused issues with filter list processing and key-value handling for HCL-defined filters.
+* Fixed formatting issues in the `clone_resource` function to prevent unnecessary line breaks in resource names.
+
 ## [0.3.17] - 2024-08-13
 
 ## What's Changed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This Makefile is an easy way to run common operations.
 
-VERSION=0.3.18-dev
+VERSION=0.3.18
 
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=github.com

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This Makefile is an easy way to run common operations.
 
-VERSION=0.3.17
+VERSION=0.3.18-dev
 
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=github.com

--- a/importer-script/functions/clone_resource.py
+++ b/importer-script/functions/clone_resource.py
@@ -44,8 +44,7 @@ def clone_resource(resource_type, resource):
             if s in resource:
                 if 'name' in resource[s]:
                     if not resource[s]['name'].startswith(ARGS.clone_prefix):
-                        resource[s]['name'] = f"{
-                            ARGS.clone_prefix}{resource[s]['name']}"
+                        resource[s]['name'] = f"{ARGS.clone_prefix}{resource[s]['name']}"
                         name = resource[s]['name']
                     else:
                         name = False

--- a/kion/internal/kionclient/filter.go
+++ b/kion/internal/kionclient/filter.go
@@ -14,32 +14,27 @@ type Filterable struct {
 	arr []Filter
 }
 
-// NewFilterable initializes a Filterable instance based on filters provided in the Terraform configuration.
-// This function dynamically creates filters based on the key-value pairs defined in the HCL.
 func NewFilterable(d *schema.ResourceData) *Filterable {
 	arr := make([]Filter, 0)
 
-	v, ok := d.GetOk("filter")
-	if !ok {
-		return nil
-	}
-
-	filterList := v.([]interface{})
-
+	filterList := d.Get("filter").([]interface{})
 	for _, v := range filterList {
 		fi := v.(map[string]interface{})
 
-		// Directly use the keys in the map as filter criteria.
-		for key, value := range fi {
-			if value != nil {
-				f := Filter{
-					key:    key,
-					keys:   strings.Split(key, "."),
-					values: []interface{}{value},
-					regex:  false, // Assume non-regex matching by default.
-				}
-				arr = append(arr, f)
+		filterName, nameOk := fi["name"].(string)
+		filterValues, valuesOk := fi["values"].([]interface{})
+		filterRegex, regexOk := fi["regex"].(bool)
+
+		if nameOk && valuesOk {
+			f := Filter{
+				key:    filterName,
+				keys:   strings.Split(filterName, "."),
+				values: filterValues,
+				regex:  regexOk && filterRegex,
 			}
+			arr = append(arr, f)
+		} else {
+			return nil
 		}
 	}
 


### PR DESCRIPTION
## [0.3.18] - 2024-08-15

## What's Changed

### Fixed

- Fixed a regression in the `NewFilterable` function that caused issues with filter list processing and key-value handling for HCL-defined filters.
- Resolved formatting issues in the `clone_resource` function to prevent unnecessary line breaks in resource names.
