### PR TITLE
refactor(resource): Clean up `last_updated` fields.

### DIFF
--- a/kion/resource_aws_account.go
+++ b/kion/resource_aws_account.go
@@ -127,11 +127,6 @@ func resourceAwsAccount() *schema.Resource {
 				Elem:         &schema.Schema{Type: schema.TypeString},
 				Description:  "A map of labels to assign to the account. The labels must already exist in Kion.",
 			},
-			"last_updated": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"linked_account_number": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/kion/resource_aws_cloudformation_template.go
+++ b/kion/resource_aws_cloudformation_template.go
@@ -28,7 +28,6 @@ func resourceAwsCloudformationTemplate() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"description": {
@@ -277,15 +276,12 @@ func resourceAwsCloudformationTemplateUpdate(ctx context.Context, d *schema.Reso
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}
+
 	return resourceAwsCloudformationTemplateRead(ctx, d, m)
 }
 

--- a/kion/resource_aws_iam_policy.go
+++ b/kion/resource_aws_iam_policy.go
@@ -28,7 +28,6 @@ func resourceAwsIamPolicy() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"aws_iam_path": {
@@ -248,12 +247,8 @@ func resourceAwsIamPolicyUpdate(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_azure_account.go
+++ b/kion/resource_azure_account.go
@@ -111,7 +111,6 @@ func resourceAzureAccount() *schema.Resource {
 			},
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"location": {

--- a/kion/resource_azure_arm_template.go
+++ b/kion/resource_azure_arm_template.go
@@ -28,7 +28,6 @@ func resourceAzureArmTemplate() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"ct_managed": {
@@ -267,12 +266,8 @@ func resourceAzureArmTemplateUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_azure_policy.go
+++ b/kion/resource_azure_policy.go
@@ -28,7 +28,6 @@ func resourceAzurePolicy() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"azure_managed_policy_def_id": {
@@ -246,12 +245,8 @@ func resourceAzurePolicyUpdate(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_azure_role.go
+++ b/kion/resource_azure_role.go
@@ -30,7 +30,6 @@ func resourceAzureRole() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"azure_managed_policy": {
@@ -252,12 +251,8 @@ func resourceAzureRoleUpdate(ctx context.Context, d *schema.ResourceData, m inte
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_cloud_rule.go
+++ b/kion/resource_cloud_rule.go
@@ -28,7 +28,6 @@ func resourceCloudRule() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"aws_cloudformation_templates": {
@@ -623,12 +622,8 @@ func resourceCloudRuleUpdate(ctx context.Context, d *schema.ResourceData, m inte
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_compliance_check.go
+++ b/kion/resource_compliance_check.go
@@ -28,7 +28,6 @@ func resourceComplianceCheck() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"azure_policy_id": {
@@ -328,12 +327,8 @@ func resourceComplianceCheckUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_compliance_standard.go
+++ b/kion/resource_compliance_standard.go
@@ -28,7 +28,6 @@ func resourceComplianceStandard() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"compliance_checks": {
@@ -285,12 +284,8 @@ func resourceComplianceStandardUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_funding_source.go
+++ b/kion/resource_funding_source.go
@@ -28,7 +28,6 @@ func resourceFundingSource() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"amount": {

--- a/kion/resource_gcp_account.go
+++ b/kion/resource_gcp_account.go
@@ -90,7 +90,6 @@ func resourceGcpAccount() *schema.Resource {
 			},
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"location": {

--- a/kion/resource_gcp_iam_role.go
+++ b/kion/resource_gcp_iam_role.go
@@ -28,7 +28,6 @@ func resourceGcpIamRole() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"name": {
@@ -251,12 +250,8 @@ func resourceGcpIamRoleUpdate(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_ou.go
+++ b/kion/resource_ou.go
@@ -28,7 +28,6 @@ func resourceOU() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"created_at": {
@@ -303,12 +302,8 @@ func resourceOUUpdate(ctx context.Context, d *schema.ResourceData, m interface{}
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_ou_cloud_access_role.go
+++ b/kion/resource_ou_cloud_access_role.go
@@ -28,7 +28,6 @@ func resourceOUCloudAccessRole() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"aws_iam_path": {

--- a/kion/resource_project.go
+++ b/kion/resource_project.go
@@ -28,7 +28,6 @@ func resourceProject() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"archived": {
@@ -465,12 +464,8 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_project_cloud_access_role.go
+++ b/kion/resource_project_cloud_access_role.go
@@ -28,7 +28,6 @@ func resourceProjectCloudAccessRole() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"accounts": {

--- a/kion/resource_saml_group_association.go
+++ b/kion/resource_saml_group_association.go
@@ -28,7 +28,6 @@ func resourceSamlGroupAssociation() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"assertion_name": {
@@ -174,12 +173,8 @@ func resourceSamlGroupAssociationUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_service-control-policy.go
+++ b/kion/resource_service-control-policy.go
@@ -28,7 +28,6 @@ func resourceServiceControlPolicy() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"aws_managed_policy": {
@@ -241,12 +240,8 @@ func resourceServiceControlPolicyUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}

--- a/kion/resource_user_group.go
+++ b/kion/resource_user_group.go
@@ -28,7 +28,6 @@ func resourceUserGroup() *schema.Resource {
 			// Notice there is no 'id' field specified because it will be created.
 			"last_updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"created_at": {
@@ -282,12 +281,8 @@ func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, m inte
 	}
 
 	if hasChanged > 0 {
-		if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Failed to set last_updated",
-				Detail:   err.Error(),
-			})
+		diags = append(diags, hc.SafeSet(d, "last_updated", time.Now().Format(time.RFC850), "Failed to set last_updated")...)
+		if len(diags) > 0 {
 			return diags
 		}
 	}


### PR DESCRIPTION
refactor(resource): remove redundant Optional attribute from last_updated field

- Removed the `Optional` attribute from the `last_updated` field across various resources as it is redundant.
- Remove the `last_updated` field from `resource_aws_account.go`
- Replaced manual `d.Set("last_updated", time.Now().Format(time.RFC850))` with `hc.SafeSet` to handle errors more consistently.