### PR TITLE
Update `amount` field from `int` to `float64` in Funding Source schema and API models

### DIFF
--- a/kion/data_source_funding_source.go
+++ b/kion/data_source_funding_source.go
@@ -47,7 +47,7 @@ func dataSourceFundingSource() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"amount": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeFloat,
 							Computed: true,
 						},
 						"description": {

--- a/kion/internal/kionclient/models_funding_source.go
+++ b/kion/internal/kionclient/models_funding_source.go
@@ -3,13 +3,13 @@ package kionclient
 // FundingSourceListResponse for: GET /api/v3/funding-source
 type FundingSourceListResponse struct {
 	Data []struct {
-		ID            int    `json:"id"`
-		Amount        int    `json:"amount"`
-		Description   string `json:"description"`
-		EndDatecode   string `json:"end_datecode"`
-		Name          string `json:"name"`
-		OUID          int    `json:"ou_id"`
-		StartDatecode string `json:"start_datecode"`
+		ID            int     `json:"id"`
+		Amount        float64 `json:"amount"`
+		Description   string  `json:"description"`
+		EndDatecode   string  `json:"end_datecode"`
+		Name          string  `json:"name"`
+		OUID          int     `json:"ou_id"`
+		StartDatecode string  `json:"start_datecode"`
 	} `json:"data"`
 	Status int `json:"status"`
 }
@@ -17,41 +17,41 @@ type FundingSourceListResponse struct {
 // FundingSourceResponse for: GET /api/v3/funding-source/{id}
 type FundingSourceResponse struct {
 	Data struct {
-		ID                 int    `json:"id"`
-		Amount             int    `json:"amount"`
-		Description        string `json:"description"`
-		EndDatecode        string `json:"end_datecode"`
-		Name               string `json:"name"`
-		OUID               int    `json:"ou_id"`
-		StartDatecode      string `json:"start_datecode"`
-		PermissionSchemeID int    `json:"permission_scheme_id"`
+		ID                 int     `json:"id"`
+		Amount             float64 `json:"amount"`
+		Description        string  `json:"description"`
+		EndDatecode        string  `json:"end_datecode"`
+		Name               string  `json:"name"`
+		OUID               int     `json:"ou_id"`
+		StartDatecode      string  `json:"start_datecode"`
+		PermissionSchemeID int     `json:"permission_scheme_id"`
 	} `json:"data"`
 	Status int `json:"status"`
 }
 
 // FundingSourceCreate for: POST /api/v3/funding-source
 type FundingSourceCreate struct {
-	ID                 int    `json:"id"`
-	Amount             int    `json:"amount"`
-	Description        string `json:"description"`
-	EndDatecode        string `json:"end_datecode"`
-	Name               string `json:"name"`
-	StartDatecode      string `json:"start_datecode"`
-	PermissionSchemeID int    `json:"permission_scheme_id"`
-	OUID               int    `json:"ou_id"`
-	OwnerUserGroupIds  *[]int `json:"owner_user_group_ids"`
-	OwnerUserIds       *[]int `json:"owner_user_ids"`
+	ID                 int     `json:"id"`
+	Amount             float64 `json:"amount"`
+	Description        string  `json:"description"`
+	EndDatecode        string  `json:"end_datecode"`
+	Name               string  `json:"name"`
+	StartDatecode      string  `json:"start_datecode"`
+	PermissionSchemeID int     `json:"permission_scheme_id"`
+	OUID               int     `json:"ou_id"`
+	OwnerUserGroupIds  *[]int  `json:"owner_user_group_ids"`
+	OwnerUserIds       *[]int  `json:"owner_user_ids"`
 }
 
 // FundingSourceUpdate for: PATCH /api/v3/funding-source/{id}
 type FundingSourceUpdate struct {
-	ID            int    `json:"id"`
-	Amount        int    `json:"amount"`
-	Description   string `json:"description"`
-	EndDatecode   string `json:"end_datecode"`
-	Name          string `json:"name"`
-	OUID          int    `json:"ou_id"`
-	StartDatecode string `json:"start_datecode"`
+	ID            int     `json:"id"`
+	Amount        float64 `json:"amount"`
+	Description   string  `json:"description"`
+	EndDatecode   string  `json:"end_datecode"`
+	Name          string  `json:"name"`
+	OUID          int     `json:"ou_id"`
+	StartDatecode string  `json:"start_datecode"`
 }
 
 // FundingSourcePermissionMapping

--- a/kion/resource_funding_source.go
+++ b/kion/resource_funding_source.go
@@ -32,7 +32,7 @@ func resourceFundingSource() *schema.Resource {
 				Computed: true,
 			},
 			"amount": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeFloat,
 				Required: true,
 			},
 			"description": {
@@ -102,7 +102,7 @@ func resourceFundingSourceCreate(ctx context.Context, d *schema.ResourceData, m 
 	client := m.(*hc.Client)
 
 	post := hc.FundingSourceCreate{
-		Amount:             d.Get("amount").(int),
+		Amount:             d.Get("amount").(float64),
 		Description:        d.Get("description").(string),
 		Name:               d.Get("name").(string),
 		StartDatecode:      d.Get("start_datecode").(string),
@@ -242,7 +242,7 @@ func resourceFundingSourceUpdate(ctx context.Context, d *schema.ResourceData, m 
 	// Determine if the attributes that are updatable are changed.
 	if d.HasChanges("amount", "description", "end_datecode", "name", "ou_id", "start_datecode") {
 		req := hc.FundingSourceUpdate{
-			Amount:        d.Get("amount").(int),
+			Amount:        d.Get("amount").(float64),
 			Description:   d.Get("description").(string),
 			Name:          d.Get("name").(string),
 			EndDatecode:   d.Get("end_datecode").(string),


### PR DESCRIPTION
### Changed
- Updated the `amount` field in the Funding Source schema from `int` to `float64` to accommodate more precise financial data in the Terraform resource definitions and API models.
  - This change affects both the resource creation and update processes.
  - Updated `data_source_funding_source`, `resource_funding_source`, and related internal API client models to reflect this change.
