### PR TITLE
feat: add funding source ID to data source output

### DIFF
--- a/kion/data_source_funding_source.go
+++ b/kion/data_source_funding_source.go
@@ -54,6 +54,10 @@ func dataSourceFundingSource() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						"name": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -99,6 +103,7 @@ func dataSourceFundingSourceRead(ctx context.Context, d *schema.ResourceData, m 
 		data := make(map[string]interface{})
 		data["amount"] = item.Amount
 		data["description"] = item.Description
+		data["id"] = item.ID
 		data["name"] = item.Name
 		data["ou_id"] = item.OUID
 		data["start_datecode"] = item.StartDatecode


### PR DESCRIPTION
Add the funding source ID field to the data source schema and include it in the response data mapping. This allows users to reference the unique identifier of funding sources in their Terraform configurations.