### PR TITLE
Improves handling of account locations and date format validation.

### DIFF
--- a/docs/resources/aws_account.md
+++ b/docs/resources/aws_account.md
@@ -82,7 +82,7 @@ output "kion_account_id" {
 - `move_project_settings` (Block Set, Max: 1) Parameters used when moving an account between Kion projects.  These settings are ignored unless moving an account. (see [below for nested schema](#nestedblock--move_project_settings))
 - `project_id` (Number) The ID of the Kion project to place this account within. If empty, the account will be placed within the account cache.
 - `skip_access_checking` (Boolean) True to skip periodic access checking on the account.
-- `start_datecode` (String) Date when the AWS account will starting submitting payments against a funding source (YYYY-MM).  Required if placing an account within a project.
+- `start_datecode` (String) Date when the AWS account will starting submitting payments against a funding source (YYYY-MM). Required if placing an account within a project.
 - `use_org_account_info` (Boolean) True to keep the account name and email address in Kion in sync with the account name and email address as set in AWS Organization.
 
 ### Read-Only

--- a/kion/resource_aws_account.go
+++ b/kion/resource_aws_account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -200,7 +201,11 @@ func resourceAwsAccount() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: "Date when the AWS account will starting submitting payments against a funding source (YYYY-MM).  Required if placing an account within a project.",
+				Description: "Date when the AWS account will starting submitting payments against a funding source (YYYY-MM). Required if placing an account within a project.",
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`^\d{4}-\d{2}$`),
+					"start_datecode must be in the format YYYY-MM (e.g., '2024-03')",
+				),
 			},
 			"use_org_account_info": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
## Changed
- Enhanced account location detection to try project location first before falling back to cache
- Added schema-level validation for `start_datecode` format to enforce YYYY-MM pattern
- Updated documentation for consistent formatting and clarity

## Fixed
- Fixed issue where `terraform state rm` would fail with 500 errors for project accounts with unset location field
- Fixed handling of account location detection for older state files that may not have location set
- Fixed validation of `start_datecode` to catch incorrect formats (e.g., YYYYMM) during plan phase instead of at API call