### PR TITLE
fix: improve account location handling and import behavior

### DIFF
--- a/docs/resources/aws_account.md
+++ b/docs/resources/aws_account.md
@@ -7,10 +7,13 @@ description: |-
   If account_number is provided, an existing account will be imported into Kion, otherwise a new AWS account will be created.  If project_id is provided the account will be added to the corresponding project, otherwise the account will be added to the account cache.
   Once added, an account can be moved between projects or in and out of the account cache by changing the project_id.  When moving accounts between projects, use move_project_settings to control how financials will be treated between the old and new project.
   When importing existing Kion accounts into terraform state, you can use one of these methods:
+  
   Default import (tries project first, then cache):
-  terraform import kionawsaccount.example 123Explicit project account import:
-  terraform import kionawsaccount.example account_id=123Explicit cache account import:
-  terraform import kionawsaccount.example accountcacheid=123
+  terraform import kion_aws_account.example 123
+  Explicit project account import:
+  terraform import kion_aws_account.example account_id=123
+  Explicit cache account import:
+  terraform import kion_aws_account.example account_cache_id=123
   NOTE: This resource requires Kion v3.8.4 or greater.
 ---
 

--- a/kion/resource_aws_account.go
+++ b/kion/resource_aws_account.go
@@ -41,6 +41,14 @@ func resourceAwsAccount() *schema.Resource {
 		DeleteContext: resourceAwsAccountDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+				// Clean the ID before reading
+				ID := d.Id()
+				if strings.HasPrefix(ID, "account_id=") {
+					d.SetId(strings.TrimPrefix(ID, "account_id="))
+				} else if strings.HasPrefix(ID, "account_cache_id=") {
+					d.SetId(strings.TrimPrefix(ID, "account_cache_id="))
+				}
+
 				resourceAwsAccountRead(ctx, d, m)
 				return []*schema.ResourceData{d}, nil
 			},


### PR DESCRIPTION
This commit enhances the account location handling logic in the Terraform provider:

- Respect explicit location settings during imports with account_id/account_cache_id prefixes
- Prevent fallback to project location when cache location is explicitly requested
- Add better error messages that include the attempted location
- Clean account IDs consistently during import and read operations
- Add debug logging to track original and cleaned IDs during operations
- Simplify location determination logic by consolidating conditions
- Fix ID cleaning in AWS account importer to match shared account behavior