### PR TITLE
fix: Prevent concurrent OU creation database constraint violations

### DIFF
--- a/kion/resource_ou_extended.go
+++ b/kion/resource_ou_extended.go
@@ -13,6 +13,12 @@ func OUChanges(client *hc.Client, d *schema.ResourceData, diags diag.Diagnostics
 	// Handle OU move.
 	if d.HasChanges("parent_ou_id") {
 		hasChanged++
+
+		// Get the global OU mutex
+		mu := getOUMutex(0)
+		mu.Lock()
+		defer mu.Unlock()
+
 		arrParentOUID, _, _, err := hc.AssociationChangedInt(d, "parent_ou_id")
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{


### PR DESCRIPTION
This commit resolves an issue where creating multiple organizational units concurrently resulted in database constraint violations with the error "Duplicate entry '2' for key 'ou_nested_set.PRIMARY'".

The fix implements a global mutex to serialize all OU operations (create and move), ensuring that the nested set model in the database maintains its integrity during hierarchical operations.

This prevents errors when creating OUs at any level of the hierarchy, particularly when creating multiple child OUs under different parents simultaneously in Terraform.