### PR TITLE
Make kion_user data source use same filter structure as other data so…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Deprecated
 Removed
 Fixed
 
+## Unreleased
+
+### Fixed
+
+- Make `kion_user` use the same filter {} structure as other data resources
+
 ## [0.3.26] - 2025-07-11
 
 ### Changed

--- a/examples/data-sources/kion_user/data-source.tf
+++ b/examples/data-sources/kion_user/data-source.tf
@@ -1,30 +1,38 @@
 # Find all enabled users
 data "kion_user" "active_users" {
   filter {
-    enabled = true
+    name   = "enabled"
+    values = [true]
   }
 }
 
 # Find specific user by username
 data "kion_user" "devops_lead" {
   filter {
-    username = "jsmith"
-    enabled  = true
+    name   = "username"
+    values = ["jsmith"]
+  }
+  filter {
+    name   = "enabled"
+    values = [true]
   }
 }
 
 # Find users by username pattern (multiple users)
 data "kion_user" "engineering_team" {
   filter {
-    username = "eng-"
-    enabled  = true
+    name   = "username"
+    values = ["eng-.*"]
+    regex  = true
+
   }
 }
 
 # Find disabled users
 data "kion_user" "inactive_users" {
   filter {
-    enabled = false
+    name   = "enabled"
+    values = [false]
   }
 }
 
@@ -51,3 +59,4 @@ output "inactive_user_summary" {
   }
   description = "Summary of inactive users"
 }
+

--- a/kion/data_source_user.go
+++ b/kion/data_source_user.go
@@ -19,15 +19,22 @@ func dataSourceUser() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"username": {
-							Description: "The username you wish to filter by.",
+						"name": {
+							Description: "The field name whose values you wish to filter by.",
 							Type:        schema.TypeString,
-							Optional:    true,
+							Required:    true,
 						},
-						"enabled": {
-							Description: "Filter by whether the user is enabled.",
+						"regex": {
+							Description: "Dictates if the values provided should be treated as regular expressions.",
 							Type:        schema.TypeBool,
 							Optional:    true,
+							Default:     false,
+						},
+						"values": {
+							Description: "The values of the field name you specified.",
+							Type:        schema.TypeList,
+							Required:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},


### PR DESCRIPTION
…urces

The current version of the Terraform provider will return all users in all cases. The code uses the standard filter mechanism behind the scenes, but the filter schema for the data source requires a different structure. 

This change updates the schema to use `name`, `values`, and `regex` fields for the filter block.