### PR TITLE
Fix start_datecode validation failing for computed values (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/). This proj
 
 [Unreleased] - yyyy-mm-dd
 
+## [0.3.34] - 2026-03-30
+
+### Fixed
+
+- Fixed `kion_custom_account` validation failing for `start_datecode` when using a computed value (e.g., `formatdate()`) (#143)
+- Replaced `GetOk()` with `GetRawConfig()` in `CustomizeDiff` validation, as `GetOk()` returns false for unknown/computed values during the plan phase
+
 ## [0.3.33] - 2026-03-26
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This Makefile is an easy way to run common operations.
 
-VERSION=0.3.33
+VERSION=0.3.34
 
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=github.com

--- a/kion/resource_custom_account.go
+++ b/kion/resource_custom_account.go
@@ -199,13 +199,18 @@ func resourceCustomAccountDelete(ctx context.Context, d *schema.ResourceData, m 
 
 // Require startDatecode if adding to a new project
 func validateCustomAccountStartDatecode(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
-	// if start date is already set, nothing to do
-	if _, ok := d.GetOk("start_datecode"); ok {
+	// Use GetRawConfig to check if values are set in the configuration.
+	// GetOk returns false for computed/unknown values (e.g. formatdate()),
+	// which incorrectly triggers validation errors during the plan phase.
+	rawConfig := d.GetRawConfig()
+
+	// if start date is already set in config, nothing to do
+	if !rawConfig.GetAttr("start_datecode").IsNull() {
 		return nil
 	}
 
 	// if not adding to project, we don't care about start date
-	if _, ok := d.GetOk("project_id"); !ok {
+	if rawConfig.GetAttr("project_id").IsNull() {
 		return nil
 	}
 


### PR DESCRIPTION
Replace `GetOk()` with `GetRawConfig()` in `CustomizeDiff` validation for `kion_custom_account`. `GetOk()` returns false for unknown/computed values during the plan phase, causing validation to incorrectly reject computed references like `formatdate()`.

Bump version to `0.3.34`.